### PR TITLE
feat(site): add privacy-focused Umami analytics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,13 @@ description: "Sample code, tutorials, and AI prompt libraries for Microsoft Viva
 baseurl: "/viva-insights-sample-code"
 url: "https://microsoft.github.io"
 
+# Privacy-focused analytics. Add host and website_id after the shared Umami
+# service is deployed; the tracker remains disabled while either value is empty.
+umami:
+  host: "https://ca-umami-prod.lemonglacier-6a5930b7.uksouth.azurecontainerapps.io"
+  website_id: "707fe1cb-2998-4b46-beba-097dcd182238"
+  domains: "microsoft.github.io"
+
 # Branding & social sharing (consumed by jekyll-seo-tag)
 logo: /assets/images/apple-touch-icon.png
 twitter:

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -19,4 +19,7 @@
   {%- if jekyll.environment == 'production' and site.google_analytics -%}
     {%- include google-analytics.html -%}
   {%- endif -%}
+  {%- if jekyll.environment == 'production' and site.umami.host and site.umami.website_id -%}
+    {%- include umami-analytics.html -%}
+  {%- endif -%}
 </head>

--- a/_includes/umami-analytics.html
+++ b/_includes/umami-analytics.html
@@ -1,0 +1,9 @@
+<script
+  defer
+  src="{{ site.umami.host }}/script.js"
+  data-website-id="{{ site.umami.website_id }}"
+  data-domains="{{ site.umami.domains }}"
+  data-do-not-track="true"
+  data-exclude-search="true"
+  data-exclude-hash="true"></script>
+


### PR DESCRIPTION
## Summary
- add a production-only Umami tracker include
- configure the shared self-hosted Azure endpoint and dedicated website ID
- exclude local and preview traffic through production gating and domain restriction
- honor Do Not Track and exclude query strings and URL fragments

## Validation
- built the Jekyll site with the deployed configuration
- confirmed the generated tracker attributes and production endpoint
- confirmed the Umami tracker and heartbeat endpoints return HTTP 200