### PR TITLE
feat(getting-started): add R/Python language switch, refresh stale content

### DIFF
--- a/_pages/getting-started.md
+++ b/_pages/getting-started.md
@@ -10,7 +10,7 @@ last_validated: 2026-08-10
 
 # Getting Started with Viva Insights Analytics
 
-This page gets you from a blank machine to your first successful Viva Insights analysis in R or Python. For custom KPIs, multi-query joins, and automated reporting patterns, see [Essentials]({{ site.baseurl }}/essentials/) and [Advanced Analytics]({{ site.baseurl }}/advanced/) once you are set up.
+Welcome to Viva Insights sample code! This guide will help you set up your development environment and get started with analyzing Viva Insights data using R or Python. For custom KPIs, multi-query joins, and automated reporting patterns once you're up and running, see [Essentials]({{ site.baseurl }}/essentials/) and [Advanced Analytics]({{ site.baseurl }}/advanced/).
 
 {% include last-validated.html %}
 
@@ -106,13 +106,15 @@ To export a query, use the query designer in the Viva Insights Analyst portal. S
 ```r
 library(vivainsights)
 
-# import_query() standardizes column names and cleans special characters,
-# which read.csv() does not do for you.
+# Load person query data and standardize variable names
 person_data <- import_query("path/to/your/person_query.csv")
 
+# Quick exploration
 check_query(person_data)
 create_bar(person_data, metric = "Collaboration_hours")
 ```
+
+Whilst you can use `read.csv()` for reading the .csv query into your R environment, we recommend using the `import_query()` function instead from the **vivainsights** package. `import_query()` standardizes variable names and 'cleans' special characters, ensuring that you minimize the number of errors arising from variable name mismatches.
 
 No query export handy yet? Use the package's built-in sample dataset instead:
 
@@ -125,13 +127,15 @@ person_data <- pq_data
 ```python
 import vivainsights as vi
 
-# import_query() standardizes column names and cleans special characters,
-# which pd.read_csv() does not do for you.
+# Load person query data and standardize variable names
 person_data = vi.import_query("path/to/your/person_query.csv")
 
+# Quick exploration
 print(person_data.info())
 vi.create_bar(person_data, metric="Collaboration_hours")
 ```
+
+Whilst you can use `pd.read_csv()` for reading the .csv query into your Python environment, we recommend using the `import_query()` function instead from the **vivainsights** package. `import_query()` standardizes variable names and 'cleans' special characters, ensuring that you minimize the number of errors arising from variable name mismatches.
 
 No query export handy yet? Use the package's built-in sample dataset instead:
 

--- a/_pages/getting-started.md
+++ b/_pages/getting-started.md
@@ -1,348 +1,217 @@
 ---
-layout: default
+layout: page
 title: "Getting Started"
 eyebrow: "Essentials"
-description: "How to get started with Viva Insights analytics in R and Python — set up the vivainsights packages, export query data, and run your first analysis."
+description: "Set up R or Python for Viva Insights analytics. Install the vivainsights package, export your first query, and avoid the most common data pitfalls."
 permalink: /getting-started/
+css: "/assets/css/lang-switch.css"
+last_validated: 2026-08-10
 ---
 
 # Getting Started with Viva Insights Analytics
-Welcome to Viva Insights sample code! This guide will help you set up your development environment and get started with analyzing Viva Insights data using R or Python.
+
+This page gets you from a blank machine to your first successful Viva Insights analysis in R or Python. For custom KPIs, multi-query joins, and automated reporting patterns, see [Essentials]({{ site.baseurl }}/essentials/) and [Advanced Analytics]({{ site.baseurl }}/advanced/) once you are set up.
+
+{% include last-validated.html %}
+
+<div class="lang-switch" role="group" aria-label="Choose code language for this page">
+  <span class="lang-switch-label">Show code in:</span>
+  <div class="lang-switch-group">
+    <button type="button" class="lang-switch-btn" data-lang-btn="r">R</button>
+    <button type="button" class="lang-switch-btn" data-lang-btn="python">Python</button>
+  </div>
+  <span class="lang-switch-note">Remembers your choice on this device.</span>
+</div>
+<script>
+(function () {
+  var stored = null;
+  try { stored = window.localStorage.getItem('vi-lang-pref'); } catch (e) {}
+  document.documentElement.setAttribute('data-lang', stored === 'python' ? 'python' : 'r');
+})();
+</script>
 
 ---
 
-## 🔧 Setting Up R
+## Prerequisites
 
-### Prerequisites
+<div data-lang-block="r" markdown="1">
+### R
 
-Before installing R packages, ensure you have:
+- **R 4.1 or higher.** [Download R](https://cran.r-project.org/).
+- **RStudio** (recommended). [Download RStudio](https://www.rstudio.com/products/rstudio/download/).
+</div>
 
-- **R version 4.0.0 or higher** - [Download R](https://cran.r-project.org/)
-- **RStudio** (recommended) - [Download RStudio](https://www.rstudio.com/products/rstudio/download/)
+<div data-lang-block="python" markdown="1">
+### Python
 
-### Install Required R Packages
+- **Python 3.9 or higher.** [Download Python](https://www.python.org/downloads/). Python 3.7 and 3.8 have reached end-of-life and are not supported.
+- **pip**, usually included with Python.
+- **A virtual environment** (recommended), so this project's packages stay isolated from others.
+</div>
 
+## Install the vivainsights package
+
+<div data-lang-block="r" markdown="1">
 ```r
-# Install core packages from CRAN
-install.packages(c(
-  "tidyverse",    # Complete data science toolkit 
-  "vivainsights", # Microsoft Viva Insights R package
-  "igraph",       # Network analysis
-  "visNetwork"   # Interactive networks
-))
+install.packages("vivainsights")
 ```
 
-### Verify R Installation
+Add other packages only as your analysis needs them. `tidyverse` is a common companion for data wrangling, and `igraph` / `visNetwork` are useful if you plan to render network graphs yourself instead of using the package's built-in `network_p2p()` / `network_g2g()` plots.
+</div>
 
-```r
-# Load the vivainsights package
-library(vivainsights)
-
-# Check package version
-packageVersion("vivainsights")
-
-# View available functions
-help(package = "vivainsights")
-```
-
-### R Environment Setup Tips
-
-1. **Set up a project**: Create an RStudio project for your Viva Insights analysis - [Learn how to use RStudio projects](https://martinctc.github.io/blog/rstudio-projects-and-working-directories-a-beginner's-guide/)
-2. **Configure data paths**: Set up consistent paths for your data files
-3. **Enable auto-completion**: RStudio provides excellent auto-completion for vivainsights functions
-
----
-
-## 🐍 Setting Up Python
-
-### Prerequisites
-- **Python 3.9 or higher** - [Download Python](https://www.python.org/downloads/) (Python 3.7 and 3.8 have reached end-of-life and are no longer supported)
-- **pip** (usually included with Python)
-- **Virtual environment** (recommended)
-
-### Create Virtual Environment
-
+<div data-lang-block="python" markdown="1">
 ```bash
-# Create virtual environment
 python -m venv viva-insights-env
 
-# Activate virtual environment
-# On Windows:
+# Activate the virtual environment
+# Windows:
 viva-insights-env\Scripts\activate
-# On macOS/Linux:
+# macOS/Linux:
 source viva-insights-env/bin/activate
-```
 
-### Install Required Python Packages
-
-```bash
-# Core data science packages
-pip install pandas numpy matplotlib seaborn plotly
-
-# Network analysis
-pip install networkx
-
-# Jupyter notebooks
-pip install jupyter
-
-# Statistical analysis
-pip install scipy scikit-learn
-
-# Install vivainsights Python package
 pip install vivainsights
 ```
 
-### Verify Python Installation
+`vivainsights` installs `pandas` as a dependency. Add other packages such as `jupyter`, `matplotlib`, or `networkx` only as your analysis needs them.
+</div>
 
-```python
-# Import vivainsights
-import vivainsights as vi
+### Verify your installation
 
-# Check version
-print(vi.__version__)
-
-# Import other key packages
-import pandas as pd
-import numpy as np
-import matplotlib.pyplot as plt
-import seaborn as sns
-import networkx as nx
-
-print("All packages imported successfully!")
-```
-
-### Python Environment Setup Tips
-
-1. **Use Jupyter notebooks**: Great for exploratory analysis
-   ```bash
-   jupyter notebook
-   ```
-2. **Configure matplotlib**: Set up plotting preferences
-   ```python
-   import matplotlib.pyplot as plt
-   plt.style.use('seaborn-v0_8')
-   ```
-3. **Set pandas options**: Configure display options
-   ```python
-   pd.set_option('display.max_columns', None)
-   pd.set_option('display.width', None)
-   ```
-
----
-
-## 📊 Using Viva Insights Queries with R/Python
-
-### Understanding Viva Insights Query Types
-
-Viva Insights provides several types of queries that you can export and analyze:
-
-1. **Person Query**: Individual-level metrics aggregated by person and date
-2. **Meeting Query**: Meeting-level data including attendees, duration, and patterns
-3. **Group-to-Group Query**: Collaboration between organizational groups
-4. **Person-to-Person Query**: Direct collaboration between individuals
-5. **Person-to-Group Query**: Individual collaboration with organizational groups
-
-### Basic Workflow
-
-#### 1. Export Data from Viva Insights
-- Log into your Viva Insights tenant
-- Navigate to **Analyze** > **Query designer**
-- Select your query type and configure parameters
-- Export results as CSV files
-
-#### 2. Load and Explore Data
-
-The following code snippet demonstrates how to load the required packages, load the .csv query into your environment, run some quick checks on the structure of the data, and create a simple visualization: 
-
-**R Example:**
+<div data-lang-block="r" markdown="1">
 ```r
 library(vivainsights)
-library(dplyr)
-
-# Load person query data and standardizes variable names
-person_data <- import_query("path/to/your/person_query.csv")
-
-# Quick exploration
-glimpse(person_data)
-summary(person_data)
-
-# Use vivainsights functions
-person_data %>% create_bar(metric = "Email_hours")
+packageVersion("vivainsights")
+help(package = "vivainsights")
 ```
+</div>
 
-**Python Example:**
+<div data-lang-block="python" markdown="1">
 ```python
 import vivainsights as vi
-import pandas as pd
-
-# Load person query data and standardizes variable names
-person_data = vi.import_query("path/to/your/person_query.csv")
-
-# Quick exploration
-print(person_data.info())
-print(person_data.describe())
-
-# Use vivainsights functions
-vi.create_bar(person_data, metric="Email_hours")
+print(vi.__version__)
 ```
-
-Whilst you can use `read.csv()` (R) or `pd.read_csv()` (Python) for reading in the .csv query into your R or Python environment, we recommend using the `import_query()` function instead from the **vivainsights** package. `import_query()` standardizes variable names and 'cleans' special characters, ensuring that you minimize the number of errors arising from variable name mismatches. 
-
-If you do not have a person query handy, you can also try out the code using our inbuilt sample datasets from the two packages: 
-```r
-person_data = pq_data # Use in place of csv load
-```
-
-```python
-person_data = vi.load_pq_data() # Use in place of csv load
-```
-
-#### 3. Common Analysis Patterns
-
-**Time Trend Analysis:**
-```r
-# R
-person_data %>% create_trend(metric = "Collaboration_hours")
-```
-```python
-# Python
-vi.create_trend(person_data, metric="Collaboration_hours")
-```
-
-**Distribution Analysis:**
-```r
-# R
-person_data %>% create_boxplot(metric = "Meeting_hours", hrvar = "Organization")
-```
-```python
-# Python
-vi.create_boxplot(person_data, metric="Meeting_hours", hrvar="Organization")
-```
-
-**Network Analysis:**
-```r
-# R - Group-to-Group networks
-g2g_data <- import_query("path/to/g2g_query.csv")
-g2g_data %>% network_g2g(primary = "Organization", secondary = "LevelDesignation")
-```
-```python
-# Python - Group-to-Group networks
-g2g_data = vi.import_query("path/to/g2g_query.csv")
-vi.network_g2g(g2g_data, primary="Organization", secondary="LevelDesignation")
-```
-
-### Data Preparation Best Practices
-
-1. **Date Formatting**: Ensure date columns are properly formatted
-   ```r
-   # R
-   person_data$Date <- as.Date(person_data$Date)
-   ```
-   ```python
-   # Python
-   person_data['Date'] = pd.to_datetime(person_data['Date'])
-   ```
-
-2. **Handle Missing Values**: Clean your data appropriately
-   ```r
-   # R
-   person_data <- person_data %>% filter(!is.na(Email_hours))
-   ```
-   ```python
-   # Python
-   person_data = person_data.dropna(subset=['Email_hours'])
-   ```
-
-3. **Standardize Organizational Attributes**: Ensure consistent naming
-   ```r
-   # R
-   person_data <- person_data %>% 
-     mutate(Organization = str_trim(Organization))
-   ```
-   ```python
-   # Python
-   person_data['Organization'] = person_data['Organization'].str.strip()
-   ```
-
-### Advanced Integration Techniques
-
-> **Note:** The snippets in this section are **R-only**. The same results are achievable in Python with pandas (`groupby`/`merge`/`assign`) and the vivainsights Python package's `create_bar`/`create_trend` helpers; Python equivalents are not reproduced here.
-
-#### Custom Metrics and KPIs
-```r
-# R - Create custom collaboration intensity metric
-person_data <- person_data %>%
-  mutate(
-    Collaboration_intensity = 
-      (Email_hours + Meeting_hours + Instant_messages_hours) / 
-      Total_focus_hours
-  )
-```
-
-#### Multi-Query Analysis
-```r
-# R - Combine person and meeting data
-person_summary <- person_data %>%
-  group_by(PersonId, Date) %>%
-  summarise(avg_collab_hours = mean(Collaboration_hours))
-
-meeting_summary <- meeting_data %>%
-  group_by(PersonId, Date) %>%
-  summarise(total_meetings = n())
-
-combined_data <- left_join(person_summary, meeting_summary, 
-                          by = c("PersonId", "Date"))
-```
-
-#### Automated Reporting
-```r
-# R - Create automated reports
-create_report <- function(data_path, output_path) {
-  data <- import_query(data_path)
-  
-  # Generate multiple visualizations
-  bar_plot <- data %>% create_bar(metric = "Email_hours")
-  trend_plot <- data %>% create_trend(metric = "Collaboration_hours")
-  
-  # Save plots
-  ggsave(paste0(output_path, "/collaboration_bar.png"), bar_plot)
-  ggsave(paste0(output_path, "/trend_analysis.png"), trend_plot)
-}
-```
+</div>
 
 ---
 
-## 🚀 Next Steps
+## Export your data from Viva Insights
 
-Once you have your environment set up:
+Person query data is the most common starting point: one row per person per period, with HR attributes like organization, function, and level as columns. Other query types (Meeting Query, Person-to-Person, Group-to-Group, Person-to-Group) have different grains and are used for more specific analyses.
 
-1. **Explore the Examples**: Browse through our [utility scripts](https://github.com/microsoft/viva-insights-sample-code/tree/main/examples) for inspiration
-2. **Start with Person Queries**: These provide the most comprehensive individual-level insights
-3. **Try Network Analysis**: Use group-to-group queries to understand organizational collaboration patterns
-4. **Build Custom Dashboards**: Combine multiple visualizations into executive-ready reports
-5. **Join the Community**: Share your insights and get help from other practitioners
+To export a query, use the query designer in the Viva Insights Analyst portal. Since the exact navigation can change between product releases, follow the current steps in [Microsoft's own Analyst portal documentation](https://learn.microsoft.com/en-us/viva/insights/advanced/analyst/query-designer) rather than a screenshot that may go stale.
 
-### Helpful Resources
+## Load and explore your data
 
-- **[vivainsights R Documentation](https://microsoft.github.io/vivainsights/)**
-- **[vivainsights Python Documentation](https://github.com/microsoft/vivainsights-py)**
-- **[Viva Insights Documentation](https://docs.microsoft.com/en-us/viva/insights/)**
-- **[Sample Code Repository](https://github.com/microsoft/viva-insights-sample-code)**
+<div data-lang-block="r" markdown="1">
+```r
+library(vivainsights)
 
-### Need Help?
+# import_query() standardizes column names and cleans special characters,
+# which read.csv() does not do for you.
+person_data <- import_query("path/to/your/person_query.csv")
 
-- **Issues or Bugs**: [Open an issue](https://github.com/microsoft/viva-insights-sample-code/issues) on GitHub
-- **Feature Requests**: Share your ideas in our [discussions](https://github.com/microsoft/viva-insights-sample-code/discussions)
-- **Community**: Connect with other users and contributors
+check_query(person_data)
+create_bar(person_data, metric = "Collaboration_hours")
+```
+
+No query export handy yet? Use the package's built-in sample dataset instead:
+
+```r
+person_data <- pq_data
+```
+</div>
+
+<div data-lang-block="python" markdown="1">
+```python
+import vivainsights as vi
+
+# import_query() standardizes column names and cleans special characters,
+# which pd.read_csv() does not do for you.
+person_data = vi.import_query("path/to/your/person_query.csv")
+
+print(person_data.info())
+vi.create_bar(person_data, metric="Collaboration_hours")
+```
+
+No query export handy yet? Use the package's built-in sample dataset instead:
+
+```python
+person_data = vi.load_pq_data()
+```
+</div>
+
+## Avoid these common pitfalls
+
+A handful of issues account for most of the confusing results people run into with a first export:
+
+- **`IsManager` and similar flags often arrive as `"Yes"`/`"No"` text** rather than booleans, so a filter like `IsManager == TRUE` silently matches nothing.
+- **`"#N/A"` sometimes arrives as a literal string** rather than a true null, which can inflate a group's row count with a bogus category.
+- **Viva Insights suppresses small groups** (commonly under 5 people) in the portal. Reproduce that same threshold locally, or your numbers will not match what stakeholders see in the portal.
+- **Holiday and low-activity weeks** shift population-level averages in ways that can look like a real behavioral change.
+
+These are documented in full, with the fix for each, in the [Viva Insights Analysis skill's data pitfalls reference](https://github.com/microsoft/viva-insights-sample-code/blob/main/frontier-analytics/skills/viva-insights-analysis/reference/data-pitfalls.md) and the [schema documentation]({{ site.baseurl }}/frontier-analytics-schemas/).
+
+## Common analysis patterns
+
+**Time trend:**
+
+<div data-lang-block="r" markdown="1">
+```r
+create_trend(person_data, metric = "Collaboration_hours")
+```
+</div>
+<div data-lang-block="python" markdown="1">
+```python
+vi.create_trend(person_data, metric="Collaboration_hours")
+```
+</div>
+
+**Distribution by group:**
+
+<div data-lang-block="r" markdown="1">
+```r
+create_boxplot(person_data, metric = "Meeting_hours", hrvar = "Organization")
+```
+</div>
+<div data-lang-block="python" markdown="1">
+```python
+vi.create_boxplot(person_data, metric="Meeting_hours", hrvar="Organization")
+```
+</div>
+
+For organizational network analysis (who collaborates with whom, across groups or individuals), see the dedicated [Network Analysis]({{ site.baseurl }}/network/) page.
+
+---
+
+## Next steps
+
+Once your environment is set up:
+
+1. **Explore the examples.** Browse the [utility scripts](https://github.com/microsoft/viva-insights-sample-code/tree/main/examples) for runnable, real-world patterns.
+2. **Read the data pitfalls guide** above before you draw conclusions from a first export.
+3. **Try a Frontier Analytics prompt or Skill.** If you have a coding agent (GitHub Copilot, Claude Code, or similar), [Frontier]({{ site.baseurl }}/frontier-analytics/) turns an export into a finished dashboard, deck, or report.
+4. **Move on to Essentials or Advanced Analytics** for custom KPIs, multi-query joins, machine learning, and statistical testing.
+
+### Helpful resources
+
+- [vivainsights R documentation](https://microsoft.github.io/vivainsights/)
+- [vivainsights Python documentation](https://microsoft.github.io/vivainsights-py/)
+- [Viva Insights documentation](https://learn.microsoft.com/en-us/viva/insights/)
+- [Sample code repository](https://github.com/microsoft/viva-insights-sample-code)
+
+### Need help?
+
+- **Issues or bugs:** [open an issue](https://github.com/microsoft/viva-insights-sample-code/issues) on GitHub.
+- **Feature requests or questions:** share them in [discussions](https://github.com/microsoft/viva-insights-sample-code/discussions).
 
 ---
 
 ## Related pages
 
-- [Essentials]({{ site.baseurl }}/essentials/) — core utility scripts, visualizations, and custom KPIs
-- [Advanced Analytics]({{ site.baseurl }}/advanced/) — machine learning, regression, and statistical testing
-- [Network Analysis]({{ site.baseurl }}/network/) — organizational network analysis (ONA)
-- [Copilot Analytics]({{ site.baseurl }}/copilot/) — measure Microsoft Copilot adoption and impact
-- [Frontier]({{ site.baseurl }}/frontier-analytics/) — self-service analytics with coding agents and prompt libraries
+- [Essentials]({{ site.baseurl }}/essentials/): core utility scripts, visualizations, and custom KPIs
+- [Advanced Analytics]({{ site.baseurl }}/advanced/): machine learning, regression, and statistical testing
+- [Network Analysis]({{ site.baseurl }}/network/): organizational network analysis (ONA)
+- [Copilot Analytics]({{ site.baseurl }}/copilot/): measure Microsoft Copilot adoption and impact
+- [Frontier]({{ site.baseurl }}/frontier-analytics/): self-service analytics with coding agents and prompt libraries
 
-*Ready to dive deeper? Start with [Essentials]({{ site.baseurl }}/essentials/) for basic analysis scripts, or jump into [Advanced Analytics]({{ site.baseurl }}/advanced/) for sophisticated modeling techniques.*
+<script src="{{ '/assets/js/lang-switch.js' | relative_url }}"></script>

--- a/assets/css/lang-switch.css
+++ b/assets/css/lang-switch.css
@@ -1,0 +1,83 @@
+/* ------------------------------------------------------------------
+   Global R / Python language switcher.
+   Loaded per-page via `css: "/assets/css/lang-switch.css"` front matter.
+   Relies on the shared design tokens defined in site.css
+   (--primary, --ink, --text, --muted, --rule, --radius-card, --shadow-card,
+   --sticky-offset).
+
+   Unlike the per-instance Causal Toolkit tabs (assets/css/causal-toolkit.css),
+   this is a single, page-wide switch. One choice (R or Python) controls every
+   [data-lang-block] element on the page at once, and is remembered across
+   visits via localStorage, so a reader does not have to re-choose their
+   language at every section.
+   ------------------------------------------------------------------ */
+
+.lang-switch {
+  position: sticky;
+  top: var(--sticky-offset, 56px);
+  z-index: 400;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  background: rgba(255, 255, 255, 0.98);
+  border: 1px solid var(--rule, #e0e0e0);
+  border-radius: var(--radius-card, 16px);
+  box-shadow: var(--shadow-card, 0 1px 3px rgba(0, 0, 0, 0.06));
+  padding: 10px 14px;
+  margin: 0 0 1.75rem;
+  font-size: 0.9rem;
+}
+
+.lang-switch-label {
+  font-weight: 600;
+  color: var(--ink, #0E1726);
+}
+
+.lang-switch-group {
+  display: inline-flex;
+  border: 1px solid var(--rule, #e0e0e0);
+  border-radius: 999px;
+  padding: 3px;
+  gap: 2px;
+  background: #f6f7fb;
+}
+
+.lang-switch-btn {
+  appearance: none;
+  border: none;
+  background: transparent;
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text, #242424);
+  padding: 6px 16px;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.lang-switch-btn.is-active {
+  background: var(--primary, #335CCC);
+  color: #fff;
+}
+
+.lang-switch-btn:focus-visible {
+  outline: 2px solid var(--primary, #335CCC);
+  outline-offset: 2px;
+}
+
+.lang-switch-note {
+  color: var(--muted, #616161);
+  font-size: 0.8rem;
+}
+
+/* Content visibility. Default (before JS runs, or with JS disabled) shows R
+   and hides Python, so the page never flashes both languages at once. */
+html:not([data-lang="python"]) [data-lang-block="python"] { display: none; }
+html[data-lang="python"] [data-lang-block="r"] { display: none; }
+
+@media (max-width: 600px) {
+  .lang-switch {
+    position: static;
+  }
+}

--- a/assets/js/lang-switch.js
+++ b/assets/js/lang-switch.js
@@ -1,0 +1,46 @@
+/* ------------------------------------------------------------------
+   Global R / Python language switcher.
+   Wires up the buttons rendered by the `.lang-switch` markup (see
+   assets/css/lang-switch.css). A separate, tiny inline script placed right
+   next to that markup in the page runs first and applies the stored
+   preference (or the "r" default) to <html data-lang="..."> before this file
+   loads, so the page never flashes both languages before JS is ready.
+   ------------------------------------------------------------------ */
+(function () {
+  var STORAGE_KEY = 'vi-lang-pref';
+
+  function setLang(lang, persist) {
+    document.documentElement.setAttribute('data-lang', lang);
+    document.querySelectorAll('[data-lang-btn]').forEach(function (btn) {
+      var active = btn.getAttribute('data-lang-btn') === lang;
+      btn.classList.toggle('is-active', active);
+      btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+    });
+    if (persist) {
+      try { window.localStorage.setItem(STORAGE_KEY, lang); } catch (e) {
+        // localStorage can be unavailable (private browsing, disabled
+        // storage). The switch still works for the current page view.
+      }
+    }
+  }
+
+  function init() {
+    var buttons = document.querySelectorAll('[data-lang-btn]');
+    if (!buttons.length) return;
+
+    var current = document.documentElement.getAttribute('data-lang') || 'r';
+    setLang(current, false);
+
+    buttons.forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        setLang(btn.getAttribute('data-lang-btn'), true);
+      });
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## Summary

Reworks the [Getting Started](https://microsoft.github.io/viva-insights-sample-code/getting-started/) page, which had gone stale and forced readers to scroll past both R and Python content on every single example regardless of which language they use.

### A global R/Python language switch

Adds a sticky toggle at the top of the page. Choosing R or Python once hides every non-matching code block for the rest of the page, and the choice is remembered via `localStorage`, so you don't re-choose at every section. This is a new, page-wide component (`assets/css/lang-switch.css`, `assets/js/lang-switch.js`), separate from the existing per-instance Causal Toolkit tabs (`assets/css/causal-toolkit.css`), which are designed for one-off choices like "Windows vs macOS" rather than a single choice that should apply to a whole page. Content opts in with a `data-lang-block="r"` / `data-lang-block="python"` wrapper div, following the same `markdown="1"` pattern the Causal Toolkit tabs already use.

Degrades gracefully without JS: CSS alone shows R and hides Python by default, so nothing flashes both languages at once even if JavaScript fails to load.

### Content refresh

- Fixed the Python docs link (was pointing at the GitHub repo instead of the docs site) and the Viva Insights docs link (was using the retired `docs.microsoft.com` domain).
- Reconciled the R version requirement (4.1+) with `vivainsights-context.md`, which stated a different minimum.
- Trimmed the prescribed package installs down to just `vivainsights` itself, with everything else mentioned as optional. The old list (tidyverse, igraph, visNetwork, pandas, numpy, matplotlib, seaborn, plotly, networkx, jupyter, scipy, scikit-learn) was heavier than necessary and inconsistent with the minimal-setup approach used elsewhere on the site.
- Added an "Avoid these common pitfalls" section linking to the Frontier skill's [data pitfalls reference](https://github.com/microsoft/viva-insights-sample-code/blob/main/frontier-analytics/skills/viva-insights-analysis/reference/data-pitfalls.md) and the schema docs, since this page previously never mentioned things like `IsManager` arriving as text or the privacy suppression threshold.
- Removed "Advanced Integration Techniques" (custom KPIs, multi-query joins, an automated-report function). It was R-only and duplicated the purpose of the existing Essentials and Advanced Analytics pages, both of which are now linked instead.
- Replaced specific Analyst portal navigation instructions with a link to Microsoft's own current docs, since exact menu paths are the kind of detail that goes stale as the product UI changes.
- Removed emoji-prefixed headings to match the plainer style used on more recently redesigned pages, removed an em-dash from the front matter description, and added a `last_validated` stamp using the same include already used on Frontier prompt cards.

## Testing

Built the site locally with `bundle exec jekyll build` (Jekyll 4.3.4). Confirmed the new page renders correctly, the language switch markup and script tag are present in the output, and `last_validated` renders using the existing include. No template or Liquid errors.