### PR TITLE
feat(site): roll out R/Python language switch, redesign Frontier Analytics page

### DIFF
--- a/_pages/advanced.md
+++ b/_pages/advanced.md
@@ -4,6 +4,7 @@ title: "Advanced Analytics"
 eyebrow: "Advanced analytics"
 description: "Machine learning, regression, and statistical analysis for Viva Insights data, including random forest top-performer models, information value, pairwise chi-square tests, difference-in-differences intervention evaluation, meeting engagement drivers, and collaboration by time of day in R and Python."
 permalink: /advanced/
+css: "/assets/css/lang-switch.css"
 ---
 # Advanced Analytics Scripts
 
@@ -19,129 +20,156 @@ The **pairwise chi-square tests** use case is used for statistical hypothesis te
 
 The **behavioral and program analysis** examples move from modelling attributes to answering practical workplace questions. The *collaboration by time of day* scripts estimate a typical start and end of day from the hourly collaboration metrics, and they show how those hours shift by weekday and by role. The *evaluating a workplace intervention* scripts set up a treated-versus-control, difference-in-differences design so that a genuine programme effect can be separated from a company-wide or seasonal trend, which makes them directly applicable to measuring the impact of a Microsoft 365 Copilot enablement wave. The *meeting engagement drivers* scripts model in-meeting messaging as a proxy for disengagement and rank the meeting characteristics that drive it, and they then take a closer look at meeting duration to separate a real effect from simple exposure. Because the sample datasets do not contain the hourly buckets, a real intervention, or enough multi-person meetings, these examples generate small, clearly labelled simulated datasets that share the column names of a real query, so that the same downstream code runs unchanged on your own export.
 
+<div class="lang-switch" role="group" aria-label="Choose code language for this page">
+  <span class="lang-switch-label">Show code in:</span>
+  <div class="lang-switch-group">
+    <button type="button" class="lang-switch-btn" data-lang-btn="r">R</button>
+    <button type="button" class="lang-switch-btn" data-lang-btn="python">Python</button>
+  </div>
+  <span class="lang-switch-note">Remembers your choice on this device.</span>
+</div>
+<script>
+(function () {
+  var stored = null;
+  try { stored = window.localStorage.getItem('vi-lang-pref'); } catch (e) {}
+  document.documentElement.setAttribute('data-lang', stored === 'python' ? 'python' : 'r');
+})();
+</script>
 
 ## Machine Learning & Predictive Modeling
 
-### Top Performers Modeling (Python)
-**📓 [top-performers-rf.ipynb](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-python/top-performers-rf.ipynb)**
-- **Purpose**: Identify characteristics of top performers using Random Forest
-- **Language**: Python
-- **Format**: Jupyter Notebook
-- **Prerequisites**: vivainsights Python package, scikit-learn, pandas
-- **Key Features**: Feature importance analysis, model validation, performance metrics
-- **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-python/top-performers-rf.ipynb)**
+### Top Performers Modeling
 
-### Top Performers Modeling (R)
+<div data-lang-block="r" markdown="1">
 **📄 [top-performers-rf.Rmd](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-r/top-performers-rf.Rmd)**
 - **Purpose**: Identify characteristics of top performers using Random Forest
-- **Language**: R
 - **Format**: R Markdown
 - **Prerequisites**: vivainsights R package, randomForest, dplyr
 - **Key Features**: Feature importance analysis, model validation, performance metrics
 - **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-r/top-performers-rf.Rmd)**
 - **[🌐 View HTML Output](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-r/top-performers-rf.html)**
+</div>
+
+<div data-lang-block="python" markdown="1">
+**📓 [top-performers-rf.ipynb](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-python/top-performers-rf.ipynb)**
+- **Purpose**: Identify characteristics of top performers using Random Forest
+- **Format**: Jupyter Notebook
+- **Prerequisites**: vivainsights Python package, scikit-learn, pandas
+- **Key Features**: Feature importance analysis, model validation, performance metrics
+- **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-python/top-performers-rf.ipynb)**
+</div>
 
 ---
 
 ## Statistical Analysis
 
-### Information Value Analysis (Python)
-**📓 [information-value.ipynb](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-python/information-value.ipynb)**
-- **Purpose**: Calculate Information Value (IV) for feature selection and variable importance
-- **Language**: Python
-- **Format**: Jupyter Notebook
-- **Prerequisites**: vivainsights Python package, pandas, numpy
-- **Key Features**: IV calculation, binning strategies, feature ranking
-- **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-python/information-value.ipynb)**
+### Information Value Analysis
 
-### Information Value Analysis (R)
+<div data-lang-block="r" markdown="1">
 **📄 [information-value.Rmd](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-r/information-value.Rmd)**
 - **Purpose**: Calculate Information Value (IV) for feature selection and variable importance
-- **Language**: R
 - **Format**: R Markdown
 - **Prerequisites**: vivainsights R package, Information, dplyr
 - **Key Features**: IV calculation, binning strategies, feature ranking
 - **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-r/information-value.Rmd)**
+</div>
 
-### Pairwise Chi-Square Tests (Python)
-**📄 [pairwise-chisq.py](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-python/pairwise-chisq.py)**
-- **Purpose**: Perform pairwise chi-square tests for categorical variables
-- **Language**: Python
-- **Prerequisites**: vivainsights Python package, scipy, pandas
-- **Key Features**: Multiple testing correction, p-value adjustment, significance testing
-- **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-python/pairwise-chisq.py)**
+<div data-lang-block="python" markdown="1">
+**📓 [information-value.ipynb](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-python/information-value.ipynb)**
+- **Purpose**: Calculate Information Value (IV) for feature selection and variable importance
+- **Format**: Jupyter Notebook
+- **Prerequisites**: vivainsights Python package, pandas, numpy
+- **Key Features**: IV calculation, binning strategies, feature ranking
+- **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-python/information-value.ipynb)**
+</div>
 
-### Pairwise Chi-Square Tests (R)
+### Pairwise Chi-Square Tests
+
+<div data-lang-block="r" markdown="1">
 **📄 [pairwise_chisq.Rmd](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-r/pairwise_chisq.Rmd)**
 - **Purpose**: Perform pairwise chi-square tests for categorical variables
-- **Language**: R
 - **Format**: R Markdown
 - **Prerequisites**: vivainsights R package, stats
 - **Key Features**: Multiple testing correction, p-value adjustment, significance testing
 - **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-r/pairwise_chisq.Rmd)**
 - **[🌐 View HTML Output](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-r/pairwise_chisq.html)**
+</div>
+
+<div data-lang-block="python" markdown="1">
+**📄 [pairwise-chisq.py](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-python/pairwise-chisq.py)**
+- **Purpose**: Perform pairwise chi-square tests for categorical variables
+- **Prerequisites**: vivainsights Python package, scipy, pandas
+- **Key Features**: Multiple testing correction, p-value adjustment, significance testing
+- **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-python/pairwise-chisq.py)**
+</div>
 
 ---
 
 ## Behavioral & Program Analysis
 
-### Collaboration by Time of Day (Python)
-**📄 [collaboration-by-time-of-day.py](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-python/collaboration-by-time-of-day.py)**
-- **Purpose**: Estimate a typical start and end of day from hourly collaboration metrics
-- **Language**: Python
-- **Prerequisites**: vivainsights Python package, pandas, numpy
-- **Key Features**: Hourly activity matrix, two-stage aggregation, cuts by weekday and role
-- **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-python/collaboration-by-time-of-day.py)**
+### Collaboration by Time of Day
 
-### Collaboration by Time of Day (R)
+<div data-lang-block="r" markdown="1">
 **📄 [collaboration-by-time-of-day.Rmd](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-r/collaboration-by-time-of-day.Rmd)**
 - **Purpose**: Estimate a typical start and end of day from hourly collaboration metrics
-- **Language**: R
 - **Format**: R Markdown
 - **Prerequisites**: vivainsights R package, tidyverse, lubridate
 - **Key Features**: Hourly activity matrix, two-stage aggregation, cuts by weekday and role
 - **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-r/collaboration-by-time-of-day.Rmd)**
 - **[🌐 View HTML Output](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-r/collaboration-by-time-of-day.html)**
+</div>
+
+<div data-lang-block="python" markdown="1">
+**📄 [collaboration-by-time-of-day.py](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-python/collaboration-by-time-of-day.py)**
+- **Purpose**: Estimate a typical start and end of day from hourly collaboration metrics
+- **Prerequisites**: vivainsights Python package, pandas, numpy
+- **Key Features**: Hourly activity matrix, two-stage aggregation, cuts by weekday and role
+- **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-python/collaboration-by-time-of-day.py)**
+</div>
 
 ---
 
-### Evaluating a Workplace Intervention (Python)
-**📄 [evaluate-intervention.py](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-python/evaluate-intervention.py)**
-- **Purpose**: Measure a workplace intervention with a treated-vs-control difference-in-differences design
-- **Language**: Python
-- **Prerequisites**: vivainsights Python package, pandas, numpy
-- **Key Features**: Before/During/After windows, difference-in-differences, two-stage aggregation, displacement checks
-- **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-python/evaluate-intervention.py)**
+### Evaluating a Workplace Intervention
 
-### Evaluating a Workplace Intervention (R)
+<div data-lang-block="r" markdown="1">
 **📄 [evaluate-intervention.Rmd](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-r/evaluate-intervention.Rmd)**
 - **Purpose**: Measure a workplace intervention with a treated-vs-control difference-in-differences design
-- **Language**: R
 - **Format**: R Markdown
 - **Prerequisites**: vivainsights R package, tidyverse
 - **Key Features**: Before/During/After windows, difference-in-differences, two-stage aggregation, displacement checks
 - **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-r/evaluate-intervention.Rmd)**
 - **[🌐 View HTML Output](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-r/evaluate-intervention.html)**
+</div>
+
+<div data-lang-block="python" markdown="1">
+**📄 [evaluate-intervention.py](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-python/evaluate-intervention.py)**
+- **Purpose**: Measure a workplace intervention with a treated-vs-control difference-in-differences design
+- **Prerequisites**: vivainsights Python package, pandas, numpy
+- **Key Features**: Before/During/After windows, difference-in-differences, two-stage aggregation, displacement checks
+- **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-python/evaluate-intervention.py)**
+</div>
 
 ---
 
-### Meeting Engagement Drivers (Python)
-**📄 [meeting-engagement-drivers.py](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-python/meeting-engagement-drivers.py)**
-- **Purpose**: Rank the meeting characteristics that drive in-meeting messaging as a proxy for disengagement
-- **Language**: Python
-- **Prerequisites**: vivainsights Python package, scikit-learn, pandas, numpy
-- **Key Features**: Meeting-level modelling, random forest permutation importance, rate-vs-exposure duration analysis
-- **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-python/meeting-engagement-drivers.py)**
+### Meeting Engagement Drivers
 
-### Meeting Engagement Drivers (R)
+<div data-lang-block="r" markdown="1">
 **📄 [meeting-engagement-drivers.Rmd](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-r/meeting-engagement-drivers.Rmd)**
 - **Purpose**: Rank the meeting characteristics that drive in-meeting messaging as a proxy for disengagement
-- **Language**: R
 - **Format**: R Markdown
 - **Prerequisites**: vivainsights R package, tidyverse, randomForest
 - **Key Features**: Meeting-level modelling, random forest permutation importance, rate-vs-exposure duration analysis
 - **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-r/meeting-engagement-drivers.Rmd)**
 - **[🌐 View HTML Output](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-r/meeting-engagement-drivers.html)**
+</div>
+
+<div data-lang-block="python" markdown="1">
+**📄 [meeting-engagement-drivers.py](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-python/meeting-engagement-drivers.py)**
+- **Purpose**: Rank the meeting characteristics that drive in-meeting messaging as a proxy for disengagement
+- **Prerequisites**: vivainsights Python package, scikit-learn, pandas, numpy
+- **Key Features**: Meeting-level modelling, random forest permutation importance, rate-vs-exposure duration analysis
+- **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-python/meeting-engagement-drivers.py)**
+</div>
 
 ---
 
@@ -180,15 +208,19 @@ The **behavioral and program analysis** examples move from modelling attributes 
 
 ## Prerequisites
 
-### Python Environment
-```bash
-pip install vivainsights pandas numpy scikit-learn linearmodels matplotlib seaborn jupyter
-```
-
+<div data-lang-block="r" markdown="1">
 ### R Environment
 ```r
 install.packages(c("vivainsights", "dplyr", "tidyr", "ggplot2", "scales", "purrr", "randomForest", "fixest", "Information", "rmarkdown"))
 ```
+</div>
+
+<div data-lang-block="python" markdown="1">
+### Python Environment
+```bash
+pip install vivainsights pandas numpy scikit-learn linearmodels matplotlib seaborn jupyter
+```
+</div>
 
 ---
 
@@ -204,11 +236,11 @@ install.packages(c("vivainsights", "dplyr", "tidyr", "ggplot2", "scales", "purrr
 
 ## Related pages
 
-- [Causal Inference in Copilot Analytics]({{ site.baseurl }}/causal-inference/) — move beyond correlation to measure the true impact of an intervention
-- [Network Analysis]({{ site.baseurl }}/network/) — organizational network analysis (ONA) as a complementary advanced technique
-- [Copilot Analytics]({{ site.baseurl }}/copilot/) — adoption metrics and Power/Habitual user segmentation
-- [Essentials]({{ site.baseurl }}/essentials/) — utilities and visualizations to prepare your data
-- [Getting Started]({{ site.baseurl }}/getting-started/) — environment setup and first steps
+- [Causal Inference in Copilot Analytics]({{ site.baseurl }}/causal-inference/): move beyond correlation to measure the true impact of an intervention
+- [Network Analysis]({{ site.baseurl }}/network/): organizational network analysis (ONA) as a complementary advanced technique
+- [Copilot Analytics]({{ site.baseurl }}/copilot/): adoption metrics and Power/Habitual user segmentation
+- [Essentials]({{ site.baseurl }}/essentials/): utilities and visualizations to prepare your data
+- [Getting Started]({{ site.baseurl }}/getting-started/): environment setup and first steps
 
 ---
 
@@ -218,3 +250,5 @@ install.packages(c("vivainsights", "dplyr", "tidyr", "ggplot2", "scales", "purrr
 - **Statistical Analysis**: [R Stats Documentation](https://stat.ethz.ch/R-manual/R-devel/library/stats/html/00Index.html)
 - **Viva Insights**: [Package Documentation](https://microsoft.github.io/vivainsights/)
 - **Sample Data**: [Example datasets](https://github.com/microsoft/viva-insights-sample-code/tree/main/examples/example-data)
+
+<script src="{{ '/assets/js/lang-switch.js' | relative_url }}"></script>

--- a/_pages/copilot.md
+++ b/_pages/copilot.md
@@ -2,8 +2,9 @@
 layout: page
 title: "Copilot Analytics"
 eyebrow: "Copilot analytics"
-description: "Analyze Microsoft 365 Copilot usage from Viva Insights — adoption metrics, Power User and Habitual User segmentation, habit-based behavioral models, usage-segment trends over time, and causal impact analysis with difference-in-differences and event-study methods in R, Python, and Power BI."
+description: "Analyze Microsoft 365 Copilot usage from Viva Insights: adoption metrics, Power User and Habitual User segmentation, habit-based behavioral models, usage-segment trends over time, and causal impact analysis with difference-in-differences and event-study methods in R, Python, and Power BI."
 permalink: /copilot/
+css: "/assets/css/lang-switch.css"
 ---
 # Copilot Analytics Scripts
 
@@ -17,34 +18,50 @@ For more information on the Copilot Usage Segments, see this [introduction]({{ s
 
 For more inspiration on analyzing Copilot adoption and impact, have a look at our [advanced examples playbook](https://aka.ms/CopilotAdvancedAnalytics/).
 
+<div class="lang-switch" role="group" aria-label="Choose code language for this page">
+  <span class="lang-switch-label">Show code in:</span>
+  <div class="lang-switch-group">
+    <button type="button" class="lang-switch-btn" data-lang-btn="r">R</button>
+    <button type="button" class="lang-switch-btn" data-lang-btn="python">Python</button>
+  </div>
+  <span class="lang-switch-note">Remembers your choice on this device.</span>
+</div>
+<script>
+(function () {
+  var stored = null;
+  try { stored = window.localStorage.getItem('vi-lang-pref'); } catch (e) {}
+  document.documentElement.setAttribute('data-lang', stored === 'python' ? 'python' : 'r');
+})();
+</script>
+
 ---
 
 ## Advanced Analysis Scripts
 
-### Copilot Advanced Analysis (R)
+### Copilot Advanced Analysis
+
+<div data-lang-block="r" markdown="1">
 **📄 [copilot-analytics-examples.R](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-r/copilot-analytics-examples.R)**
 - **Purpose**: Comprehensive analysis of Copilot usage patterns and trends
-- **Language**: R
 - **Prerequisites**: vivainsights R package, Copilot usage data
 - **Key Analysis**: Usage segmentation, trend analysis, adoption metrics
 - **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-r/copilot-analytics-examples.R)**
+</div>
 
-### Copilot Advanced Analysis (Python)
+<div data-lang-block="python" markdown="1">
 **📄 [copilot-analytics-examples.py](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-python/copilot-analytics-examples.py)**
 - **Purpose**: Comprehensive analysis of Copilot usage patterns and trends
-- **Language**: Python
 - **Prerequisites**: vivainsights Python package, Copilot usage data
 - **Key Analysis**: Usage segmentation, trend analysis, adoption metrics
 - **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-python/copilot-analytics-examples.py)**
 
-### Copilot Analytics (Jupyter Notebook)
-**📓 [copilot-analytics-examples.ipynb](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-python/copilot-analytics-examples.ipynb)**
+**📓 [copilot-analytics-examples.ipynb](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-python/copilot-analytics-examples.ipynb)** (Jupyter Notebook)
 - **Purpose**: Interactive analysis of Copilot usage with visualizations
-- **Language**: Python
 - **Format**: Jupyter Notebook
 - **Prerequisites**: vivainsights Python package, Copilot usage data
 - **Key Features**: Step-by-step analysis, interactive visualizations
 - **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-python/copilot-analytics-examples.ipynb)**
+</div>
 
 ---
 
@@ -52,63 +69,69 @@ For more inspiration on analyzing Copilot adoption and impact, have a look at ou
 
 The examples in this section focus on measuring Copilot adoption credibly over time. The *Copilot usage segments over time* scripts sum individual Copilot-action columns, classify each person-week with `identify_usage_segments(version = "12w")`, and visualise how the mix of Power, Habitual, Novice, Low, and Non-users evolves week by week. The *difference-in-differences metric scan* runs a within-person DiD per metric across two both-licensed groups (Power vs Low Copilot users) and assembles the effects, confidence intervals, and significance into one sortable table plus a forest plot, honestly surfacing the metrics that do not move. The *event-study and difference-in-differences* example aligns each adopter on their own event time, checks the parallel-trends assumption before trusting a single headline number, and reads the within-person change net of a non-adopting control. The two causal examples build small, clearly labelled seeded simulations so that the models have something to recover; swap the simulation block for your own export before drawing conclusions.
 
-### Copilot Usage Segments Over Time (Python)
-**📄 [copilot-usage-segments-trend.py](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-python/copilot-usage-segments-trend.py)**
-- **Purpose**: Track how the mix of Copilot usage segments evolves week by week
-- **Language**: Python
-- **Prerequisites**: vivainsights Python package, pandas, numpy, matplotlib
-- **Key Features**: identify_usage_segments (12-week rolling), stacked-area segment mix, action trend
-- **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-python/copilot-usage-segments-trend.py)**
+### Copilot Usage Segments Over Time
 
-### Copilot Usage Segments Over Time (R)
+<div data-lang-block="r" markdown="1">
 **📄 [copilot-usage-segments-trend.Rmd](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-r/copilot-usage-segments-trend.Rmd)**
 - **Purpose**: Track how the mix of Copilot usage segments evolves week by week
-- **Language**: R
 - **Format**: R Markdown
 - **Prerequisites**: vivainsights R package, dplyr, tidyr, ggplot2, scales
 - **Key Features**: identify_usage_segments (12-week rolling), stacked-area segment mix, action trend
 - **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-r/copilot-usage-segments-trend.Rmd)**
 - **[🌐 View HTML Output](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-r/copilot-usage-segments-trend.html)**
+</div>
+
+<div data-lang-block="python" markdown="1">
+**📄 [copilot-usage-segments-trend.py](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-python/copilot-usage-segments-trend.py)**
+- **Purpose**: Track how the mix of Copilot usage segments evolves week by week
+- **Prerequisites**: vivainsights Python package, pandas, numpy, matplotlib
+- **Key Features**: identify_usage_segments (12-week rolling), stacked-area segment mix, action trend
+- **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-python/copilot-usage-segments-trend.py)**
+</div>
 
 ---
 
-### Difference-in-Differences Metric Scan (Python)
-**📄 [did-metric-scan.py](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-python/did-metric-scan.py)**
-- **Purpose**: Run a within-person DiD per metric (Power vs Low Copilot users) into one sortable table
-- **Language**: Python
-- **Prerequisites**: vivainsights Python package, linearmodels, pandas, numpy, matplotlib
-- **Key Features**: Per-metric TWFE DiD, significance stars, forest plot, honest reporting of null effects
-- **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-python/did-metric-scan.py)**
+### Difference-in-Differences Metric Scan
 
-### Difference-in-Differences Metric Scan (R)
+<div data-lang-block="r" markdown="1">
 **📄 [did-metric-scan.Rmd](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-r/did-metric-scan.Rmd)**
 - **Purpose**: Run a within-person DiD per metric (Power vs Low Copilot users) into one sortable table
-- **Language**: R
 - **Format**: R Markdown
 - **Prerequisites**: vivainsights R package, fixest, dplyr, tidyr, ggplot2, purrr, scales
 - **Key Features**: Per-metric TWFE DiD, significance stars, forest plot, honest reporting of null effects
 - **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-r/did-metric-scan.Rmd)**
 - **[🌐 View HTML Output](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-r/did-metric-scan.html)**
+</div>
+
+<div data-lang-block="python" markdown="1">
+**📄 [did-metric-scan.py](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-python/did-metric-scan.py)**
+- **Purpose**: Run a within-person DiD per metric (Power vs Low Copilot users) into one sortable table
+- **Prerequisites**: vivainsights Python package, linearmodels, pandas, numpy, matplotlib
+- **Key Features**: Per-metric TWFE DiD, significance stars, forest plot, honest reporting of null effects
+- **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-python/did-metric-scan.py)**
+</div>
 
 ---
 
-### Event-Study & Difference-in-Differences (Python)
-**📄 [event-study-did.py](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-python/event-study-did.py)**
-- **Purpose**: Measure within-person behaviour change around Copilot adoption with a TWFE event-study/DiD
-- **Language**: Python
-- **Prerequisites**: vivainsights Python package, linearmodels, pandas, numpy, matplotlib
-- **Key Features**: Event-time alignment, pre-trend check, person + week fixed effects, z-scored composite index
-- **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-python/event-study-did.py)**
+### Event-Study & Difference-in-Differences
 
-### Event-Study & Difference-in-Differences (R)
+<div data-lang-block="r" markdown="1">
 **📄 [event-study-did.Rmd](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-r/event-study-did.Rmd)**
 - **Purpose**: Measure within-person behaviour change around Copilot adoption with a TWFE event-study/DiD
-- **Language**: R
 - **Format**: R Markdown
 - **Prerequisites**: vivainsights R package, fixest, dplyr, tidyr, ggplot2, scales
 - **Key Features**: Event-time alignment, pre-trend check, person + week fixed effects, z-scored composite index
 - **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-r/event-study-did.Rmd)**
 - **[🌐 View HTML Output](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-r/event-study-did.html)**
+</div>
+
+<div data-lang-block="python" markdown="1">
+**📄 [event-study-did.py](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-python/event-study-did.py)**
+- **Purpose**: Measure within-person behaviour change around Copilot adoption with a TWFE event-study/DiD
+- **Prerequisites**: vivainsights Python package, linearmodels, pandas, numpy, matplotlib
+- **Key Features**: Event-time alignment, pre-trend check, person + week fixed effects, z-scored composite index
+- **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-python/event-study-did.py)**
+</div>
 
 ---
 
@@ -173,16 +196,18 @@ These five segments form a **single mutually-exclusive ladder**, evaluated top-d
 
 ## Related pages
 
-- [Copilot Usage Segments]({{ site.baseurl }}/copilot-usage-segments/) — how Power, Habitual, and Novice segments are defined
-- [DAX Calculated Columns]({{ site.baseurl }}/dax-calculated-columns/) — ready-to-use Power BI formulas for segmentation
-- [Copilot Causal Toolkit]({{ site.baseurl }}/copilot-causal-toolkit/) — measure the causal impact of Copilot on business outcomes
-- [Causal Inference in Copilot Analytics]({{ site.baseurl }}/causal-inference/) — methods for isolating Copilot's true effect
-- [Frontier Prompt Library]({{ site.baseurl }}/frontier-analytics-prompts/) — generate Copilot reports and dashboards with coding agents
+- [Copilot Usage Segments]({{ site.baseurl }}/copilot-usage-segments/): how Power, Habitual, and Novice segments are defined
+- [DAX Calculated Columns]({{ site.baseurl }}/dax-calculated-columns/): ready-to-use Power BI formulas for segmentation
+- [Copilot Causal Toolkit]({{ site.baseurl }}/copilot-causal-toolkit/): measure the causal impact of Copilot on business outcomes
+- [Causal Inference in Copilot Analytics]({{ site.baseurl }}/causal-inference/): methods for isolating Copilot's true effect
+- [Frontier Prompt Library]({{ site.baseurl }}/frontier-analytics-prompts/): generate Copilot reports and dashboards with coding agents
 
 ---
 
 ## Need Help?
 
-- **Copilot Analytics Documentation**: [Viva Insights Copilot Guide](https://docs.microsoft.com/en-us/viva/insights/)
+- **Copilot Analytics Documentation**: [Viva Insights Copilot Guide](https://learn.microsoft.com/en-us/viva/insights/)
 - **Power BI Integration**: [DAX Documentation](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/dax/calculated-columns/README.md)
 - **Sample Data**: [Example datasets](https://github.com/microsoft/viva-insights-sample-code/tree/main/examples/example-data)
+
+<script src="{{ '/assets/js/lang-switch.js' | relative_url }}"></script>

--- a/_pages/essentials.md
+++ b/_pages/essentials.md
@@ -4,6 +4,7 @@ title: "Essentials"
 eyebrow: "Essentials"
 description: "Essential R and Python scripts for getting started with Viva Insights: utilities, custom visualizations, and custom KPI generation."
 permalink: /essentials/
+css: "/assets/css/lang-switch.css"
 ---
 # Essential Viva Insights Scripts
 
@@ -13,47 +14,65 @@ This page provides some essential scripts to let you get started with analysis i
 * run a range of custom visualizations on your Viva Insights data
 * create custom KPIs or segments using a combination of Viva Insights metrics and organizational / survey data
 
+<div class="lang-switch" role="group" aria-label="Choose code language for this page">
+  <span class="lang-switch-label">Show code in:</span>
+  <div class="lang-switch-group">
+    <button type="button" class="lang-switch-btn" data-lang-btn="r">R</button>
+    <button type="button" class="lang-switch-btn" data-lang-btn="python">Python</button>
+  </div>
+  <span class="lang-switch-note">Remembers your choice on this device.</span>
+</div>
+<script>
+(function () {
+  var stored = null;
+  try { stored = window.localStorage.getItem('vi-lang-pref'); } catch (e) {}
+  document.documentElement.setAttribute('data-lang', stored === 'python' ? 'python' : 'r');
+})();
+</script>
+
 ## Utility Scripts
 
+<div data-lang-block="r" markdown="1">
 ### R Utilities
 Essential functions and utilities for R-based analysis.
 
 **📁 [Utility code for R](https://github.com/microsoft/viva-insights-sample-code/tree/main/examples/utility-r)**
 - **Purpose**: Collection of utility functions for common Viva Insights analysis tasks
-- **Language**: R
 - **Format**: Multiple R files
 - **Prerequisites**: vivainsights R package
+</div>
 
----
-
+<div data-lang-block="python" markdown="1">
 ### Python Utilities
 Essential functions and utilities for Python-based analysis.
 
 **📁 [Utility code for Python](https://github.com/microsoft/viva-insights-sample-code/tree/main/examples/utility-python)**
 - **Purpose**: Collection of utility functions for common Viva Insights analysis tasks
-- **Language**: Python
 - **Format**: Multiple Python files
 - **Prerequisites**: vivainsights Python package
+</div>
 
 ---
 
 ## Visualization Scripts
 
-### Creating Essential Visualizations (R)
+### Creating Essential Visualizations
+
+<div data-lang-block="r" markdown="1">
 **📄 [create-example-visuals.R](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-r/create-example-visuals.R)**
 - **Purpose**: Generate standard Viva Insights visualizations
-- **Language**: R
 - **Prerequisites**: vivainsights R package, ggplot2
 - **Key Functions**: Bar charts, line plots, network diagrams
 - **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-r/create-example-visuals.R)**
+</div>
 
-### Creating Essential Visualizations (Python)
+<div data-lang-block="python" markdown="1">
 **📄 [create-example-visuals.py](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-python/create-example-visuals.py)**
 - **Purpose**: Generate standard Viva Insights visualizations
-- **Language**: Python
 - **Prerequisites**: vivainsights Python package, matplotlib, seaborn
 - **Key Functions**: Bar charts, line plots, network diagrams
 - **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-python/create-example-visuals.py)**
+</div>
 
 ---
 
@@ -65,7 +84,7 @@ Essential functions and utilities for Python-based analysis.
 - **Language**: R
 - **Format**: Markdown tutorial with code examples
 - **Prerequisites**: vivainsights R package
-- **📖 Full tutorial**: [Generate Custom KPIs in R]({{ site.baseurl }}/generate-custom-kpi/) — step-by-step walkthrough on this site
+- **📖 Full tutorial**: [Generate Custom KPIs in R]({{ site.baseurl }}/generate-custom-kpi/), a step-by-step walkthrough on this site
 - **[📥 Download Script](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-r/generate-custom-kpi/generate_kpis.R)**
 
 ---
@@ -88,11 +107,11 @@ Essential functions and utilities for Python-based analysis.
 
 ## Related pages
 
-- [Getting Started]({{ site.baseurl }}/getting-started/) — set up your R or Python environment and run your first analysis
-- [Generate Custom KPIs in R]({{ site.baseurl }}/generate-custom-kpi/) — full walkthrough of the custom-KPI workflow
-- [Joining People Skills Data]({{ site.baseurl }}/skills-data-join/) — combine People Skills data with Viva Insights metrics
-- [Advanced Analytics]({{ site.baseurl }}/advanced/) — machine learning, regression, and statistical testing
-- [Network Analysis]({{ site.baseurl }}/network/) — organizational network analysis (ONA)
+- [Getting Started]({{ site.baseurl }}/getting-started/): set up your R or Python environment and run your first analysis
+- [Generate Custom KPIs in R]({{ site.baseurl }}/generate-custom-kpi/): full walkthrough of the custom-KPI workflow
+- [Joining People Skills Data]({{ site.baseurl }}/skills-data-join/): combine People Skills data with Viva Insights metrics
+- [Advanced Analytics]({{ site.baseurl }}/advanced/): machine learning, regression, and statistical testing
+- [Network Analysis]({{ site.baseurl }}/network/): organizational network analysis (ONA)
 
 ---
 
@@ -101,3 +120,5 @@ Essential functions and utilities for Python-based analysis.
 - **R Package Documentation**: [vivainsights R](https://microsoft.github.io/vivainsights/)
 - **Python Package Documentation**: [vivainsights Python](https://microsoft.github.io/vivainsights-py/)
 - **Sample Data**: [Example datasets](https://github.com/microsoft/viva-insights-sample-code/tree/main/examples/example-data)
+
+<script src="{{ '/assets/js/lang-switch.js' | relative_url }}"></script>

--- a/_pages/frontier-analytics.md
+++ b/_pages/frontier-analytics.md
@@ -13,7 +13,47 @@ Frontier is a collection of ready-to-use prompts, schema guides, and example out
 
 > **Note:** Everything in this section is sample code and starter assets. It is not production software. Outputs require review, validation, and adaptation to your environment before use.
 
-{% include responsible-use.html %}
+---
+
+## Which asset should I use?
+
+Frontier offers four ways to bring this work into a coding agent. Pick a card to jump straight to what you need, or see the full comparison below for more nuance.
+
+<div class="vi-card-grid" markdown="0">
+  <a class="vi-card" href="{{ site.baseurl }}/frontier-analytics-prompts/">
+    <span class="vi-card-icon">📋</span>
+    <span class="vi-card-title">Prompt Library</span>
+    <span class="vi-card-desc">Copy a ready-made prompt into your agent for a one-off analysis. No setup required.</span>
+    <span class="vi-card-more">Browse prompts →</span>
+  </a>
+  <a class="vi-card" href="https://github.com/microsoft/viva-insights-sample-code/tree/main/frontier-analytics/skills">
+    <span class="vi-card-icon">🧠</span>
+    <span class="vi-card-title">Skills</span>
+    <span class="vi-card-desc">Your agent loads the right conventions automatically for ongoing work. Needs a Skill-compatible agent, for example GitHub Copilot CLI or Claude Code.</span>
+    <span class="vi-card-more">View on GitHub →</span>
+  </a>
+  <a class="vi-card" href="https://github.com/microsoft/viva-insights-sample-code/blob/main/vivainsights-context.md">
+    <span class="vi-card-icon">📄</span>
+    <span class="vi-card-title">Context file</span>
+    <span class="vi-card-desc">Paste once at the start of a session. A lighter fallback when your agent doesn't support Skills.</span>
+    <span class="vi-card-more">View on GitHub →</span>
+  </a>
+  <a class="vi-card" href="https://github.com/microsoft/viva-insights-sample-code/tree/main/frontier-analytics/mcp">
+    <span class="vi-card-icon">🔌</span>
+    <span class="vi-card-title">MCP (concept only)</span>
+    <span class="vi-card-desc">A protocol-level integration that would let an agent query prompts and schemas directly from a server. Not implemented yet.</span>
+    <span class="vi-card-more">Read the design intent →</span>
+  </a>
+</div>
+
+### Full comparison
+
+| Mechanism | What it is | Status | Use it when |
+|-----------|------------|--------|-------------|
+| [Prompt Library]({{ site.baseurl }}/frontier-analytics-prompts/) | Structured text you copy and paste into any coding agent for a single analysis task. | Available | Your agent does not support Skills or MCP, or you want a one-off analysis without any setup. |
+| Skills | A packaged capability that a compatible coding agent loads automatically, so it applies the right conventions without you pasting anything. See the [skills folder on GitHub](https://github.com/microsoft/viva-insights-sample-code/tree/main/frontier-analytics/skills). | Available | Your coding agent supports the Skill format (for example GitHub Copilot CLI or Claude Code) and you want ongoing, repeated Viva Insights work to follow consistent conventions. |
+| [vivainsights-context.md](https://github.com/microsoft/viva-insights-sample-code/blob/main/vivainsights-context.md) | A single context file you paste once at the start of a session. | Available | Your agent does not support Skills, but you still want to avoid repeating setup instructions in every prompt. |
+| [mcp/](https://github.com/microsoft/viva-insights-sample-code/tree/main/frontier-analytics/mcp) | A protocol-level integration that would let an agent query prompts, schemas, and tools directly from a server. | Concept only, no server implemented | Not yet. Read the folder for the design intent and to track progress. |
 
 ---
 
@@ -28,34 +68,18 @@ You do not need to be a software engineer. If you can export a CSV from Viva Ins
 
 ---
 
-## Which asset should I use?
-
-Frontier offers four ways to bring this work into a coding agent. They solve overlapping problems, so use this table to pick the right one before browsing further.
-
-| Mechanism | What it is | Status | Use it when |
-|-----------|------------|--------|-------------|
-| [Prompt Library]({{ site.baseurl }}/frontier-analytics-prompts/) | Structured text you copy and paste into any coding agent for a single analysis task. | Available | Your agent does not support Skills or MCP, or you want a one-off analysis without any setup. |
-| Skills | A packaged capability that a compatible coding agent loads automatically, so it applies the right conventions without you pasting anything. See the [skills folder on GitHub](https://github.com/microsoft/viva-insights-sample-code/tree/main/frontier-analytics/skills). | Available | Your coding agent supports the Skill format (for example GitHub Copilot CLI or Claude Code) and you want ongoing, repeated Viva Insights work to follow consistent conventions. |
-| [vivainsights-context.md](https://github.com/microsoft/viva-insights-sample-code/blob/main/vivainsights-context.md) | A single context file you paste once at the start of a session. | Available | Your agent does not support Skills, but you still want to avoid repeating setup instructions in every prompt. |
-| [mcp/](https://github.com/microsoft/viva-insights-sample-code/tree/main/frontier-analytics/mcp) | A protocol-level integration that would let an agent query prompts, schemas, and tools directly from a server. | Concept only, no server implemented | Not yet. Read the folder for the design intent and to track progress. |
-
----
-
 ## What's inside
 
 | Section | Description |
 |---------|-------------|
-| [Prompt Library]({{ site.baseurl }}/frontier-analytics-prompts/) | Structured, ready-to-paste prompts for coding agents. Covers Copilot adoption tracking, user segmentation, ROI estimation, and Purview audit log analysis. |
 | [Schema Documentation]({{ site.baseurl }}/frontier-analytics-schemas/) | Data dictionaries for person query exports, Purview audit logs, join patterns, and common data pitfalls. |
 
 Additional resources available on GitHub:
 
 | Folder | Description |
 |--------|-------------|
-| [skills/](https://github.com/microsoft/viva-insights-sample-code/tree/main/frontier-analytics/skills) | Agent Skills. Packaged capabilities that a compatible coding agent loads automatically for ongoing Viva Insights work. |
 | [examples/](https://github.com/microsoft/viva-insights-sample-code/tree/main/frontier-analytics/examples) | Sample output specifications describing what a finished deliverable looks like. |
 | [templates/](https://github.com/microsoft/viva-insights-sample-code/tree/main/frontier-analytics/templates) | Templates for contributing new prompt cards, skills, and schema docs. |
-| [mcp/](https://github.com/microsoft/viva-insights-sample-code/tree/main/frontier-analytics/mcp) | Concept and sample configuration for Model Context Protocol (MCP) integration. Not yet implemented: there is no MCP server today, see the folder's README for the design intent. |
 
 ---
 
@@ -99,7 +123,12 @@ Once installed, open the agent in a folder that has R or Python available, then 
 2. **Iterate in small steps.** If the output is not right, ask the agent to fix one thing at a time rather than re-generating everything.
 3. **Validate the output.** Spot-check row counts, date ranges, and aggregation logic. Coding agents can make plausible-looking mistakes.
 4. **Use the vivainsights packages.** The R and Python packages handle common data validation and visualization tasks. Prompts that reference these functions tend to produce cleaner code.
-5. **Keep your data private.** Do not paste raw data into cloud-based agents unless your organization's data policies allow it. Use local or enterprise-hosted agents when working with sensitive HR data.
+
+See "Responsible use & data privacy" below before you work with real HR data.
+
+---
+
+{% include responsible-use.html %}
 
 ---
 

--- a/_pages/network.md
+++ b/_pages/network.md
@@ -2,8 +2,9 @@
 layout: page
 title: "Network Analysis"
 eyebrow: "Advanced analytics · Network"
-description: "Organizational network analysis (ONA) with Viva Insights — visualize and analyze collaboration networks at the group-to-group and person-to-person level in R and Python."
+description: "Organizational network analysis (ONA) with Viva Insights. Visualize and analyze collaboration networks at the group-to-group and person-to-person level in R and Python."
 permalink: /network/
+css: "/assets/css/lang-switch.css"
 ---
 # Network Analysis Scripts
 
@@ -37,47 +38,67 @@ In Viva Insights, network metrics are available in four main queries.
 3. The **person-to-person query** is an edgelist with each row representign the collaboration with one person with another. 
 4. The **person-to-group query** which is an edgelist with each row representing the collaboration of each person with respect to a grouping (organizational) attribute.
 
+<div class="lang-switch" role="group" aria-label="Choose code language for this page">
+  <span class="lang-switch-label">Show code in:</span>
+  <div class="lang-switch-group">
+    <button type="button" class="lang-switch-btn" data-lang-btn="r">R</button>
+    <button type="button" class="lang-switch-btn" data-lang-btn="python">Python</button>
+  </div>
+  <span class="lang-switch-note">Remembers your choice on this device.</span>
+</div>
+<script>
+(function () {
+  var stored = null;
+  try { stored = window.localStorage.getItem('vi-lang-pref'); } catch (e) {}
+  document.documentElement.setAttribute('data-lang', stored === 'python' ? 'python' : 'r');
+})();
+</script>
+
 ---
 
 ## Group-to-Group Network Analysis
 
-### Customizing Group-to-Group Networks (Python)
-**📄 [custom-network-g2g.py](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-python/custom-network-g2g.py)**
-- **Purpose**: Create customized group-to-group collaboration network visualizations
-- **Language**: Python
-- **Prerequisites**: vivainsights Python package, networkx, matplotlib
-- **Key Features**: Custom styling, filtering, layout algorithms, export options
-- **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-python/custom-network-g2g.py)**
+### Customizing Group-to-Group Networks
 
-### Customizing Group-to-Group Networks (R)
+<div data-lang-block="r" markdown="1">
 **📄 [custom-network-g2g.Rmd](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-r/custom-network-g2g.Rmd)**
 - **Purpose**: Create customized group-to-group collaboration network visualizations
-- **Language**: R
 - **Format**: R Markdown
 - **Prerequisites**: vivainsights R package, igraph, ggplot2
 - **Key Features**: Custom styling, filtering, layout algorithms, export options
 - **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-r/custom-network-g2g.Rmd)**
+</div>
+
+<div data-lang-block="python" markdown="1">
+**📄 [custom-network-g2g.py](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-python/custom-network-g2g.py)**
+- **Purpose**: Create customized group-to-group collaboration network visualizations
+- **Prerequisites**: vivainsights Python package, networkx, matplotlib
+- **Key Features**: Custom styling, filtering, layout algorithms, export options
+- **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-python/custom-network-g2g.py)**
+</div>
 
 ---
 
 ## Person-to-Person Network Analysis
 
-### Customizing Person-to-Person Networks (Python)
-**📄 [custom-network-p2p.py](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-python/custom-network-p2p.py)**
-- **Purpose**: Create customized person-to-person collaboration network visualizations
-- **Language**: Python
-- **Prerequisites**: vivainsights Python package, networkx, matplotlib
-- **Key Features**: Individual-level analysis, community detection, centrality measures
-- **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-python/custom-network-p2p.py)**
+### Customizing Person-to-Person Networks
 
-### Customizing Person-to-Person Networks (R)
+<div data-lang-block="r" markdown="1">
 **📄 [custom-network-p2p.Rmd](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-r/custom-network-p2p.Rmd)**
 - **Purpose**: Create customized person-to-person collaboration network visualizations
-- **Language**: R
 - **Format**: R Markdown
 - **Prerequisites**: vivainsights R package, igraph, ggplot2
 - **Key Features**: Individual-level analysis, community detection, centrality measures
 - **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-r/custom-network-p2p.Rmd)**
+</div>
+
+<div data-lang-block="python" markdown="1">
+**📄 [custom-network-p2p.py](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-python/custom-network-p2p.py)**
+- **Purpose**: Create customized person-to-person collaboration network visualizations
+- **Prerequisites**: vivainsights Python package, networkx, matplotlib
+- **Key Features**: Individual-level analysis, community detection, centrality measures
+- **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-python/custom-network-p2p.py)**
+</div>
 
 ---
 
@@ -175,15 +196,19 @@ In Viva Insights, network metrics are available in four main queries.
 
 ## Prerequisites
 
-### Python Environment
-```bash
-pip install vivainsights networkx matplotlib seaborn plotly pandas numpy
-```
-
+<div data-lang-block="r" markdown="1">
 ### R Environment
 ```r
 install.packages(c("vivainsights", "igraph", "ggplot2", "dplyr", "visNetwork"))
 ```
+</div>
+
+<div data-lang-block="python" markdown="1">
+### Python Environment
+```bash
+pip install vivainsights networkx matplotlib seaborn plotly pandas numpy
+```
+</div>
 
 ---
 
@@ -191,7 +216,7 @@ install.packages(c("vivainsights", "igraph", "ggplot2", "dplyr", "visNetwork"))
 
 1. **Data Quality**: Ensure clean, complete collaboration data
 2. **Privacy**: Anonymize person-level data when appropriate
-3. **Interpretation**: Focus on actionable insights, not just metrics
+3. **Interpretation**: Focus on actionable insights rather than metrics alone
 4. **Validation**: Cross-check network insights with qualitative feedback
 5. **Temporal Analysis**: Track network changes over time for trends
 
@@ -199,10 +224,10 @@ install.packages(c("vivainsights", "igraph", "ggplot2", "dplyr", "visNetwork"))
 
 ## Related pages
 
-- [Essentials]({{ site.baseurl }}/essentials/) — core utilities and visualizations to prepare your data
-- [Advanced Analytics]({{ site.baseurl }}/advanced/) — predictive modeling and statistical testing
-- [Joining People Skills Data]({{ site.baseurl }}/skills-data-join/) — enrich network analysis with People Skills data
-- [Getting Started]({{ site.baseurl }}/getting-started/) — environment setup and first steps
+- [Essentials]({{ site.baseurl }}/essentials/): core utilities and visualizations to prepare your data
+- [Advanced Analytics]({{ site.baseurl }}/advanced/): predictive modeling and statistical testing
+- [Joining People Skills Data]({{ site.baseurl }}/skills-data-join/): enrich network analysis with People Skills data
+- [Getting Started]({{ site.baseurl }}/getting-started/): environment setup and first steps
 
 ---
 
@@ -212,3 +237,5 @@ install.packages(c("vivainsights", "igraph", "ggplot2", "dplyr", "visNetwork"))
 - **Visualization**: [Matplotlib](https://matplotlib.org/) | [ggplot2](https://ggplot2.tidyverse.org/)
 - **Viva Insights**: [Package Documentation](https://microsoft.github.io/vivainsights/)
 - **Sample Data**: [Example datasets](https://github.com/microsoft/viva-insights-sample-code/tree/main/examples/example-data)
+
+<script src="{{ '/assets/js/lang-switch.js' | relative_url }}"></script>


### PR DESCRIPTION
## Summary

Two grouped changes, as discussed:

### 1. Roll out the R/Python language switch site-wide

The [Getting Started](https://microsoft.github.io/viva-insights-sample-code/getting-started/) page (PR #6) introduced a sticky R/Python toggle that hides non-matching code for the whole page. This applies the same treatment to the four other pages with the same "R section, then Python section, repeated for every example" problem:

- `advanced.md`: 6 paired topics (Top Performers Modeling, Information Value, Pairwise Chi-Square, Collaboration by Time of Day, Workplace Intervention, Meeting Engagement Drivers) plus Prerequisites
- `network.md`: 2 paired topics (G2G and P2P customization) plus Prerequisites. Two R-only sections (Extended ONA Analysis, ONA Group Analysis) are left as is
- `copilot.md`: 4 paired topics (Advanced Analysis, Usage Segments Over Time, DiD Metric Scan, Event-Study & DiD)
- `essentials.md`: Utility Scripts and Visualization Scripts. Custom KPI Generation and Getting Started Tutorials are already single-language and untouched

Paired topics now share **one heading** with the R and Python implementations toggled beneath it (instead of duplicating the heading per language), which also avoids duplicate entries in the floating table of contents.

Not included: `skills-example-join.md` interleaves R and Python with substantial prose across 5 long business-scenario sections rather than paired code dumps, and is a much bigger rewrite than the others. Flagging it as a separate follow-up rather than bundling it in here.

### 2. Redesign the Frontier Analytics page

- Adds a card grid (Prompt Library, Skills, Context file, MCP) right after the intro, reusing the `.vi-card-grid` component already used on the Causal Toolkit hub page, as the primary at-a-glance way to pick an asset. The existing detailed comparison table stays directly below as "Full comparison" for anyone who wants the fuller nuance, rather than being removed.
- Moves the responsible-use / data-privacy callout from immediately after the intro (before the page even explains what Frontier is) to its own section near the bottom, after the getting-started workflow and tips. Removed the now-duplicate "Keep your data private" tip from the Tips list.
- Trims "What's inside" to drop the Prompt Library, `skills/`, and `mcp/` rows now covered by the cards, keeping only what the cards don't (schema docs, `examples/`, `templates/`).

Also fixed several pre-existing em-dashes and one "not just" construction on the pages touched here, to match house style.

## Testing

Built the site locally with `bundle exec jekyll build` (Jekyll 4.3.4, no errors). Confirmed rendered output for all 5 pages has the expected `data-lang-block` / `vi-card` counts and that markdown inside the language-block divs parses correctly (spot-checked `advanced.md`'s Top Performers Modeling section and the Frontier card grid).