### PR TITLE
docs(copilot): fix wall-of-text section, add reciprocal links, rename colliding heading

### DIFF
--- a/_pages/copilot.md
+++ b/_pages/copilot.md
@@ -67,9 +67,11 @@ For more inspiration on analyzing Copilot adoption and impact, have a look at ou
 
 ## Adoption Tracking & Causal Analysis
 
-The examples in this section focus on measuring Copilot adoption credibly over time. The *Copilot usage segments over time* scripts sum individual Copilot-action columns, classify each person-week with `identify_usage_segments(version = "12w")`, and visualise how the mix of Power, Habitual, Novice, Low, and Non-users evolves week by week. The *difference-in-differences metric scan* runs a within-person DiD per metric across two both-licensed groups (Power vs Low Copilot users) and assembles the effects, confidence intervals, and significance into one sortable table plus a forest plot, honestly surfacing the metrics that do not move. The *event-study and difference-in-differences* example aligns each adopter on their own event time, checks the parallel-trends assumption before trusting a single headline number, and reads the within-person change net of a non-adopting control. The two causal examples build small, clearly labelled seeded simulations so that the models have something to recover; swap the simulation block for your own export before drawing conclusions.
+The examples in this section focus on measuring Copilot adoption credibly over time. The two causal examples build small, clearly labelled seeded simulations so that the models have something to recover; swap the simulation block for your own export before drawing conclusions.
 
 ### Copilot Usage Segments Over Time
+
+Sums individual Copilot-action columns, classifies each person-week with `identify_usage_segments(version = "12w")`, and visualises how the mix of Power, Habitual, Novice, Low, and Non-users evolves week by week.
 
 <div data-lang-block="r" markdown="1">
 **📄 [copilot-usage-segments-trend.Rmd](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-r/copilot-usage-segments-trend.Rmd)**
@@ -93,6 +95,8 @@ The examples in this section focus on measuring Copilot adoption credibly over t
 
 ### Difference-in-Differences Metric Scan
 
+Runs a within-person DiD per metric across two both-licensed groups (Power vs Low Copilot users) and assembles the effects, confidence intervals, and significance into one sortable table plus a forest plot, honestly surfacing the metrics that do not move.
+
 <div data-lang-block="r" markdown="1">
 **📄 [did-metric-scan.Rmd](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-r/did-metric-scan.Rmd)**
 - **Purpose**: Run a within-person DiD per metric (Power vs Low Copilot users) into one sortable table
@@ -114,6 +118,8 @@ The examples in this section focus on measuring Copilot adoption credibly over t
 ---
 
 ### Event-Study & Difference-in-Differences
+
+Aligns each adopter on their own event time, checks the parallel-trends assumption before trusting a single headline number, and reads the within-person change net of a non-adopting control.
 
 <div data-lang-block="r" markdown="1">
 **📄 [event-study-did.Rmd](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-r/event-study-did.Rmd)**
@@ -183,7 +189,7 @@ These five segments form a **single mutually-exclusive ladder**, evaluated top-d
 
 ---
 
-## Getting Started
+## Analysis Workflow
 
 1. **Export Copilot Usage Data** from Viva Insights
 2. **Choose Your Analysis Method**:
@@ -201,6 +207,10 @@ These five segments form a **single mutually-exclusive ladder**, evaluated top-d
 - [Copilot Causal Toolkit]({{ site.baseurl }}/copilot-causal-toolkit/): measure the causal impact of Copilot on business outcomes
 - [Causal Inference in Copilot Analytics]({{ site.baseurl }}/causal-inference/): methods for isolating Copilot's true effect
 - [Frontier Prompt Library]({{ site.baseurl }}/frontier-analytics-prompts/): generate Copilot reports and dashboards with coding agents
+- [Advanced Analytics]({{ site.baseurl }}/advanced/): machine learning, regression, and statistical testing
+- [Network Analysis]({{ site.baseurl }}/network/): organizational network analysis (ONA)
+- [Essentials]({{ site.baseurl }}/essentials/): utilities and visualizations to prepare your data
+- [Getting Started]({{ site.baseurl }}/getting-started/): environment setup and first steps
 
 ---
 


### PR DESCRIPTION
## Summary

Content review of `_pages/copilot/` surfaced three gaps, following the same pattern already found and fixed on `essentials.md` (#8) and `advanced.md` (#10).

## Changes

1. **Wall-of-text section.** "Adoption Tracking & Causal Analysis" had one dense paragraph explaining three scripts (usage-segments trend, DiD metric scan, event-study) before any of their subheadings. Redistributed as short 1-2 sentence lead-ins directly under each subheading instead, keeping the section-level intro to one sentence.
2. **Missing reciprocal links.** Getting Started, Advanced Analytics, and Network Analysis all link to Copilot Analytics in their Related pages, but Copilot Analytics didn't link back to any of Essentials, Getting Started, Advanced Analytics, or Network Analysis. Added the four missing links.
3. **Naming collision.** This page had its own `## Getting Started` section (a quick numbered workflow: export data, choose method, select time frame, run analysis), which collides with the actual site-wide **Getting Started** page. Renamed to `## Analysis Workflow`, mirroring the identical fix already made to essentials.md in #8 (`Getting Started Tutorials` → `Introductory Notebooks`).

## Testing

Built the site locally with `bundle exec jekyll build` (no errors). Confirmed the renamed heading and all newly added links resolve to the correct pages.
