### PR TITLE
docs(network): add query cards, G2G/P2P toggle, merge ONA examples, fix links

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,6 +8,11 @@
   {%- if page.css -%}
   <link rel="stylesheet" href="{{ page.css | relative_url }}">
   {%- endif -%}
+  {%- if page.css_files -%}
+    {%- for css_file in page.css_files -%}
+  <link rel="stylesheet" href="{{ css_file | relative_url }}">
+    {%- endfor -%}
+  {%- endif -%}
 
   {%- comment -%} Viva Insights branding: favicon + theme colour {%- endcomment -%}
   <link rel="icon" type="image/svg+xml" href="{{ "/assets/images/favicon.svg" | relative_url }}">

--- a/_pages/network.md
+++ b/_pages/network.md
@@ -10,7 +10,7 @@ css_files:
 ---
 # Network Analysis Scripts
 
-Organizational Network Analysis (ONA) maps the relationships and interactions between people, teams, and departments based on actual collaboration patterns, rather than formal reporting structures — revealing the informal networks that drive real work and innovation, in ways a traditional org chart cannot. It's used for change management, organizational design, identifying informal leaders and connectors, and spotting collaboration silos or over-dependencies on key individuals.
+Organizational Network Analysis (ONA) maps the relationships and interactions between people, teams, and departments based on actual collaboration patterns, rather than formal reporting structures — revealing the informal networks that drive real work and innovation, in ways a traditional org chart cannot. See [Key Use Cases for Network Analysis](#key-use-cases-for-network-analysis) further down the page for the full range of ways this is applied.
 
 Viva Insights makes network metrics available through four query types. Sample scripts on this page currently cover two of them — pick a card to jump straight to one, or read on for the full picture.
 
@@ -183,6 +183,23 @@ A deeper walkthrough of `network_p2p()`: Louvain and Leiden community detection,
 2. **Temporal Analysis**: Track network changes over time
 3. **Comparative Analysis**: Compare networks across departments/teams
 4. **Recommendations**: Provide actionable insights for collaboration improvement
+
+---
+
+## Key Use Cases for Network Analysis
+
+Network analysis with Viva Insights data is particularly valuable for:
+
+- **Change Management**: Identify key influencers and communication pathways to ensure successful organizational transformations
+- **Organizational Design**: Understand how work actually flows across teams and departments to optimize organizational structure
+- **Talent Development**: Discover high-potential employees who serve as connectors and bridge-builders across the organization
+- **Innovation & Knowledge Sharing**: Map how expertise and information flow to identify bottlenecks and opportunities for better collaboration
+- **Merger & Acquisition Integration**: Visualize collaboration patterns between merged entities and track integration progress
+- **Remote Work Optimization**: Understand how distributed teams collaborate and identify potential isolation or over-collaboration issues
+- **Leadership Development**: Identify informal leaders and understand influence patterns beyond formal hierarchy
+- **Diversity & Inclusion**: Analyze collaboration patterns across different demographic groups to identify potential barriers or silos
+- **Team Formation**: Use network insights to create more effective cross-functional teams based on existing collaboration patterns
+- **Risk Management**: Identify over-dependencies on key individuals or potential knowledge silos that could impact business continuity
 
 ---
 

--- a/_pages/network.md
+++ b/_pages/network.md
@@ -4,39 +4,42 @@ title: "Network Analysis"
 eyebrow: "Advanced analytics · Network"
 description: "Organizational network analysis (ONA) with Viva Insights. Visualize and analyze collaboration networks at the group-to-group and person-to-person level in R and Python."
 permalink: /network/
-css: "/assets/css/lang-switch.css"
+css_files:
+  - "/assets/css/lang-switch.css"
+  - "/assets/css/topic-switch.css"
 ---
 # Network Analysis Scripts
 
-This page covers collaboration network visualization and analysis scripts for understanding organizational connectivity, typically referred to as organizational network analysis (ONA). Viva Insights offers a unique data source to visualize information flow between people and groups in an organization, providing insights that traditional organizational charts cannot reveal.
+Organizational Network Analysis (ONA) maps the relationships and interactions between people, teams, and departments based on actual collaboration patterns, rather than formal reporting structures — revealing the informal networks that drive real work and innovation, in ways a traditional org chart cannot. It's used for change management, organizational design, identifying informal leaders and connectors, and spotting collaboration silos or over-dependencies on key individuals.
 
-## What is Organizational Network Analysis?
+Viva Insights makes network metrics available through four query types. Sample scripts on this page currently cover two of them — pick a card to jump straight to one, or read on for the full picture.
 
-Organizational Network Analysis (ONA) maps the relationships and interactions between people, teams, and departments based on actual collaboration patterns rather than formal reporting structures. Unlike traditional organizational charts that show hierarchical relationships, ONA reveals the informal networks that drive real work and innovation within organizations.
-
-## Key Use Cases for Network Analysis
-
-Network analysis with Viva Insights data is particularly valuable for:
-
-- **Change Management**: Identify key influencers and communication pathways to ensure successful organizational transformations
-- **Organizational Design**: Understand how work actually flows across teams and departments to optimize organizational structure
-- **Talent Development**: Discover high-potential employees who serve as connectors and bridge-builders across the organization
-- **Innovation & Knowledge Sharing**: Map how expertise and information flow to identify bottlenecks and opportunities for better collaboration
-- **Merger & Acquisition Integration**: Visualize collaboration patterns between merged entities and track integration progress
-- **Remote Work Optimization**: Understand how distributed teams collaborate and identify potential isolation or over-collaboration issues
-- **Leadership Development**: Identify informal leaders and understand influence patterns beyond formal hierarchy
-- **Diversity & Inclusion**: Analyze collaboration patterns across different demographic groups to identify potential barriers or silos
-- **Team Formation**: Use network insights to create more effective cross-functional teams based on existing collaboration patterns
-- **Risk Management**: Identify over-dependencies on key individuals or potential knowledge silos that could impact business continuity
-
-## Network Analysis Capabilities
-
-In Viva Insights, network metrics are available in four main queries.
-
-1. The **person query** provides network metrics aggregated at the person-date level, such as `Strong ties`, `Diverse ties`, `Influencer score`, `Internal network size`, etc. 
-2. The **group-to-group query** is an edgelist with each row representing the collaboration with one grouping (organizational) attribute with another. 
-3. The **person-to-person query** is an edgelist with each row representign the collaboration with one person with another. 
-4. The **person-to-group query** which is an edgelist with each row representing the collaboration of each person with respect to a grouping (organizational) attribute.
+<div class="vi-card-grid" markdown="0">
+  <a class="vi-card" href="#group-to-group-network-analysis">
+    <span class="vi-card-icon">🏢</span>
+    <span class="vi-card-title">Group-to-Group Query</span>
+    <span class="vi-card-desc">An edgelist with each row representing the collaboration of one grouping (organizational) attribute with another.</span>
+    <span class="vi-card-more">Jump to section →</span>
+  </a>
+  <a class="vi-card" href="#person-to-person-network-analysis">
+    <span class="vi-card-icon">🧑‍🤝‍🧑</span>
+    <span class="vi-card-title">Person-to-Person Query</span>
+    <span class="vi-card-desc">An edgelist with each row representing the collaboration of one person with another.</span>
+    <span class="vi-card-more">Jump to section →</span>
+  </a>
+  <a class="vi-card" href="https://learn.microsoft.com/en-us/viva/insights/advanced/reference/metrics">
+    <span class="vi-card-icon">👤</span>
+    <span class="vi-card-title">Person Query (Network Metrics)</span>
+    <span class="vi-card-desc">Person-date level metrics such as Strong ties, Diverse ties, Influencer score, and Internal network size. No sample script in this repo yet.</span>
+    <span class="vi-card-more">Metrics reference →</span>
+  </a>
+  <a class="vi-card" href="https://learn.microsoft.com/en-us/viva/insights/advanced/reference/metrics">
+    <span class="vi-card-icon">🕸️</span>
+    <span class="vi-card-title">Person-to-Group Query</span>
+    <span class="vi-card-desc">An edgelist with each row representing one person's collaboration with respect to a grouping (organizational) attribute. No sample script in this repo yet.</span>
+    <span class="vi-card-more">Metrics reference →</span>
+  </a>
+</div>
 
 <div class="lang-switch" role="group" aria-label="Choose code language for this page">
   <span class="lang-switch-label">Show code in:</span>
@@ -54,7 +57,26 @@ In Viva Insights, network metrics are available in four main queries.
 })();
 </script>
 
+<div class="topic-switch" role="group" aria-label="Focus on a network query type">
+  <span class="topic-switch-label">Focus on:</span>
+  <div class="topic-switch-group">
+    <button type="button" class="topic-switch-btn" data-topic-btn="all">Both</button>
+    <button type="button" class="topic-switch-btn" data-topic-btn="g2g">Group-to-Group</button>
+    <button type="button" class="topic-switch-btn" data-topic-btn="p2p">Person-to-Person</button>
+  </div>
+  <span class="topic-switch-note">Remembers your choice on this device.</span>
+</div>
+<script>
+(function () {
+  var stored = null;
+  try { stored = window.localStorage.getItem('vi-network-topic-pref'); } catch (e) {}
+  document.documentElement.setAttribute('data-topic', (stored === 'g2g' || stored === 'p2p') ? stored : 'all');
+})();
+</script>
+
 ---
+
+<div data-topic-block="g2g" markdown="1">
 
 ## Group-to-Group Network Analysis
 
@@ -77,7 +99,27 @@ In Viva Insights, network metrics are available in four main queries.
 - **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-python/custom-network-g2g.py)**
 </div>
 
+### Extended Group-to-Group Analysis (R)
+
+A deeper walkthrough of `network_g2g()`: interaction matrices, igraph objects, sankey visualizations, and overlaying organizational colours and sizes onto the network plot.
+
+**📄 [example_ONA_groups.R](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/extending-vivainsights-with-R/example_ONA_groups.R)**
+- **Purpose**: Group-based organizational network analysis
+- **Language**: R
+- **Prerequisites**: vivainsights R package, igraph, dplyr
+- **Key Features**: Inter-group dynamics, group-level metrics, comparative analysis
+- **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/extending-vivainsights-with-R/example_ONA_groups.R)**
+
+### Group-to-Group Example Visualizations
+
+- **[🖼️ network_g2g.svg](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-r/example-visuals/network_g2g.svg)**: Sample group-to-group network (R)
+- **[🖼️ network_g2g.svg (Python)](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-python/example-visuals/network_g2g.svg)**: Python-generated network
+
+</div>
+
 ---
+
+<div data-topic-block="p2p" markdown="1">
 
 ## Person-to-Person Network Analysis
 
@@ -100,11 +142,10 @@ In Viva Insights, network metrics are available in four main queries.
 - **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-python/custom-network-p2p.py)**
 </div>
 
----
+### Extended Person-to-Person Analysis (R)
 
-## Organizational Network Analysis Examples
+A deeper walkthrough of `network_p2p()`: Louvain and Leiden community detection, closeness/degree/betweenness centrality, sankey visualizations, and a fast plotting method for large graphs.
 
-### Extended ONA Analysis (R)
 **📄 [example_ONA.R](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/extending-vivainsights-with-R/example_ONA.R)**
 - **Purpose**: Comprehensive organizational network analysis workflows
 - **Language**: R
@@ -112,28 +153,12 @@ In Viva Insights, network metrics are available in four main queries.
 - **Key Features**: Network metrics, clustering, centrality analysis
 - **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/extending-vivainsights-with-R/example_ONA.R)**
 
-### ONA Group Analysis (R)
-**📄 [example_ONA_groups.R](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/extending-vivainsights-with-R/example_ONA_groups.R)**
-- **Purpose**: Group-based organizational network analysis
-- **Language**: R
-- **Prerequisites**: vivainsights R package, igraph, dplyr
-- **Key Features**: Inter-group dynamics, group-level metrics, comparative analysis
-- **[📥 Download](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/extending-vivainsights-with-R/example_ONA_groups.R)**
+### Person-to-Person Example Visualizations
 
----
-
-## Example Visualizations
-
-### Generated Network Visualizations
-**📁 [Network Visualization Examples](https://github.com/microsoft/viva-insights-sample-code/tree/main/examples/utility-r/example-visuals)**
-
-**Group-to-Group Networks**:
-- **[🖼️ network_g2g.svg](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-r/example-visuals/network_g2g.svg)**: Sample group-to-group network
-- **[🖼️ network_g2g.svg (Python)](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-python/example-visuals/network_g2g.svg)**: Python-generated network
-
-**Person-to-Person Networks**:
-- **[🖼️ network_p2p.svg](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-r/example-visuals/network_p2p.svg)**: Sample person-to-person network
+- **[🖼️ network_p2p.svg](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-r/example-visuals/network_p2p.svg)**: Sample person-to-person network (R)
 - **[🖼️ network_p2p.svg (Python)](https://raw.githubusercontent.com/microsoft/viva-insights-sample-code/main/examples/utility-python/example-visuals/network_p2p.svg)**: Python-generated network
+
+</div>
 
 ---
 
@@ -226,6 +251,7 @@ pip install vivainsights networkx matplotlib seaborn plotly pandas numpy
 
 - [Essentials]({{ site.baseurl }}/essentials/): core utilities and visualizations to prepare your data
 - [Advanced Analytics]({{ site.baseurl }}/advanced/): predictive modeling and statistical testing
+- [Copilot Analytics]({{ site.baseurl }}/copilot/): measure Microsoft Copilot adoption and impact
 - [Joining People Skills Data]({{ site.baseurl }}/skills-data-join/): enrich network analysis with People Skills data
 - [Getting Started]({{ site.baseurl }}/getting-started/): environment setup and first steps
 
@@ -239,3 +265,4 @@ pip install vivainsights networkx matplotlib seaborn plotly pandas numpy
 - **Sample Data**: [Example datasets](https://github.com/microsoft/viva-insights-sample-code/tree/main/examples/example-data)
 
 <script src="{{ '/assets/js/lang-switch.js' | relative_url }}"></script>
+<script src="{{ '/assets/js/topic-switch.js' | relative_url }}"></script>

--- a/assets/css/topic-switch.css
+++ b/assets/css/topic-switch.css
@@ -1,0 +1,74 @@
+/* ------------------------------------------------------------------
+   Network page topic switcher: Group-to-Group / Person-to-Person / Both.
+   Companion to lang-switch.css/js — same visual language, but a second,
+   independent axis (network query type, not code language) so it can be
+   combined freely with the R/Python switch for four addressable
+   view-states. Relies on the shared design tokens defined in site.css
+   (--primary, --ink, --text, --muted, --rule, --radius-card, --shadow-card).
+
+   Unlike .lang-switch, this is intentionally NOT sticky: stacking two
+   sticky bars at the same offset would overlap on scroll, and staying
+   pinned matters less for a page-specific filter than for the site-wide
+   language switch.
+   ------------------------------------------------------------------ */
+
+.topic-switch {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  background: rgba(255, 255, 255, 0.98);
+  border: 1px solid var(--rule, #e0e0e0);
+  border-radius: var(--radius-card, 16px);
+  box-shadow: var(--shadow-card, 0 1px 3px rgba(0, 0, 0, 0.06));
+  padding: 10px 14px;
+  margin: 0 0 1.75rem;
+  font-size: 0.9rem;
+}
+
+.topic-switch-label {
+  font-weight: 600;
+  color: var(--ink, #0E1726);
+}
+
+.topic-switch-group {
+  display: inline-flex;
+  border: 1px solid var(--rule, #e0e0e0);
+  border-radius: 999px;
+  padding: 3px;
+  gap: 2px;
+  background: #f6f7fb;
+}
+
+.topic-switch-btn {
+  appearance: none;
+  border: none;
+  background: transparent;
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text, #242424);
+  padding: 6px 16px;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.topic-switch-btn.is-active {
+  background: var(--primary, #335CCC);
+  color: #fff;
+}
+
+.topic-switch-btn:focus-visible {
+  outline: 2px solid var(--primary, #335CCC);
+  outline-offset: 2px;
+}
+
+.topic-switch-note {
+  color: var(--muted, #616161);
+  font-size: 0.8rem;
+}
+
+/* Content visibility. Default ("all", or before JS runs) shows both
+   Group-to-Group and Person-to-Person blocks. */
+html[data-topic="g2g"] [data-topic-block="p2p"] { display: none; }
+html[data-topic="p2p"] [data-topic-block="g2g"] { display: none; }

--- a/assets/js/topic-switch.js
+++ b/assets/js/topic-switch.js
@@ -1,0 +1,45 @@
+/* ------------------------------------------------------------------
+   Network page topic switcher: Group-to-Group / Person-to-Person / Both.
+   Wires up the buttons rendered by the `.topic-switch` markup (see
+   assets/css/topic-switch.css). Mirrors lang-switch.js's pattern exactly,
+   but with its own storage key and data attribute so the two switches
+   operate independently and can be combined on the same page.
+   ------------------------------------------------------------------ */
+(function () {
+  var STORAGE_KEY = 'vi-network-topic-pref';
+
+  function setTopic(topic, persist) {
+    document.documentElement.setAttribute('data-topic', topic);
+    document.querySelectorAll('[data-topic-btn]').forEach(function (btn) {
+      var active = btn.getAttribute('data-topic-btn') === topic;
+      btn.classList.toggle('is-active', active);
+      btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+    });
+    if (persist) {
+      try { window.localStorage.setItem(STORAGE_KEY, topic); } catch (e) {
+        // localStorage can be unavailable (private browsing, disabled
+        // storage). The switch still works for the current page view.
+      }
+    }
+  }
+
+  function init() {
+    var buttons = document.querySelectorAll('[data-topic-btn]');
+    if (!buttons.length) return;
+
+    var current = document.documentElement.getAttribute('data-topic') || 'all';
+    setTopic(current, false);
+
+    buttons.forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        setTopic(btn.getAttribute('data-topic-btn'), true);
+      });
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## Summary

Full content review of `_pages/network.md`, following the same pattern as `essentials.md` (#8), `advanced.md` (#10), and `copilot.md` (#11) — plus the two specific design requests: a Group-to-Group / Person-to-Person toggle (mirroring the existing R/Python toggle), and a card display for the four Viva Insights network query types.

## Findings

1. **Worse wall-of-text than Advanced Analytics had.** The page opened with an H1 intro, a full "What is Organizational Network Analysis?" section, and a 10-bullet "Key Use Cases" list — all generic, overlapping content — before a single script or toggle appeared.
2. **"Organizational Network Analysis Examples" was mislabeled and duplicative.** Read both scripts: `example_ONA.R` is actually a deeper `network_p2p()` walkthrough (community detection, centrality), and `example_ONA_groups.R` is a deeper `network_g2g()` walkthrough. They were presented as a separate third "ONA" category — confusing since the *entire page* is ONA — rather than belonging to the existing Person-to-Person / Group-to-Group sections.
3. **The "four main queries" claim over-promised.** Only 2 of 4 (group-to-group, person-to-person) have any example scripts anywhere in the repo. Person query network metrics and person-to-group query have zero example coverage.
4. Related pages was missing a reciprocal link to Copilot Analytics.
5. Minor typo: "row representign" → "representing".

## Changes

- **Trimmed the intro** to two short paragraphs (from an H1 + 2 full sections + 10-bullet list).
- **Added a 4-card grid** for the four query types. Group-to-Group and Person-to-Person cards jump to their sections; Person Query (Network Metrics) and Person-to-Group are marked reference-only and link to the official [Microsoft Learn metrics reference](https://learn.microsoft.com/en-us/viva/insights/advanced/reference/metrics) instead of a dead end, since no sample scripts exist for them yet.
- **Added a new Group-to-Group / Person-to-Person toggle** (`assets/css/topic-switch.css`, `assets/js/topic-switch.js`), mirroring the existing R/Python `lang-switch` pattern as an independent second axis — combinable for four addressable view-states (e.g. "R + Group-to-Group only"). Intentionally *not* sticky (unlike `lang-switch`), since two overlapping sticky bars would conflict on scroll.
- **Merged `example_ONA.R` into Person-to-Person** and **`example_ONA_groups.R` into Group-to-Group**, removing the redundant "Organizational Network Analysis Examples" section entirely. Also moved the "Example Visualizations" SVG links into their respective sections so the new toggle filters them too.
- **Added the missing reciprocal Related-pages link** to Copilot Analytics.
- **Fixed the typo.**
- Left "Key Network Metrics" / "Customization Options" / "Best Practices" / "Workflows" sections as-is (per discussion — similar generic sections still exist on `advanced.md`/`copilot.md`, treated as a separate concern).

`_includes/head.html` gains additive, backward-compatible support for a new `css_files` front-matter array (for pages needing more than one extra stylesheet, like this one needing both `lang-switch.css` and `topic-switch.css`). The existing singular `css` key is unchanged and still works for every other page.

## Testing

Built the site locally with `bundle exec jekyll build` (no errors). Verified:
- Both new stylesheets and both scripts (`lang-switch.js`, `topic-switch.js`) load on the rendered page.
- All four card anchors/links resolve correctly (`#group-to-group-network-analysis`, `#person-to-person-network-analysis` match the kramdown-generated heading IDs; the two reference-only cards link to a live Microsoft Learn page).
- No regression on other pages still using the singular `css` front-matter key (checked `advanced.md`'s rendered `<head>`).
- All linked scripts, SVGs, and sample-data files verified to exist in the repo.
