### PR TITLE
docs: language and styling improvements to the Meeting Effectiveness Playbook

### DIFF
--- a/_pages/meeting-effectiveness-playbook.md
+++ b/_pages/meeting-effectiveness-playbook.md
@@ -1,10 +1,10 @@
 ---
 layout: article
 title: "The Meeting Effectiveness Playbook"
-description: "An operational playbook for fixing meeting culture — what to change before, during, and after meetings, how Copilot helps, and how to measure progress with Viva Insights."
+description: "An operational playbook for fixing meeting culture, covering what to change before, during, and after meetings, how Copilot helps, and how to measure progress with Viva Insights."
 permalink: /articles/meeting-effectiveness-playbook/
 eyebrow: "Copilot Analytics Lab · PANDAS Team · May 2026"
-dek: "Meeting culture is a design problem with a design solution. This playbook is the operating manual — what to change before, during, and after meetings, how Copilot helps, and how to measure progress."
+dek: "Meeting culture is a design problem with a design solution. This playbook covers what to change before, during, and after meetings, how Copilot helps, and how to measure progress."
 byline: "By the PANDAS team · A Copilot Analytics Lab brief"
 read_time: "10 min read"
 css: "/assets/css/article.css"
@@ -22,26 +22,26 @@ css: "/assets/css/article.css"
 </ol>
 </nav>
 
-<p class="lead">This is the operating manual. It assumes you already accept that meeting culture is worth fixing and that the evidence supports doing so — and goes straight to the work: what to change in the meetings you run, how Copilot fits in, the structural levers that scale, and the six signals that tell you whether any of it is working.</p>
+<p class="lead">This playbook assumes you already accept that meeting culture is worth fixing, and goes straight to the work: what to change in the meetings you run, how Copilot fits in, the structural levers that scale, and the six signals that tell you whether any of it is working.</p>
 
 <aside class="callout reveal" markdown="1">
 <span class="callout-label">Research foundation</span>
-For the *why* — meeting science, the multitasking taxonomy, the evidence on AI's effect on collaboration, and the adoption gap between licence and behaviour — read the companion brief, [**When AI Met the Meeting**]({{ site.baseurl }}/articles/when-ai-met-the-meeting/), first. This playbook is the operational counterpart.
+For the *why* (meeting science, the multitasking taxonomy, the evidence on AI's effect on collaboration, and the adoption gap between licence and behaviour), read the companion brief, [**When AI Met the Meeting**]({{ site.baseurl }}/articles/when-ai-met-the-meeting/), first. This playbook is the operational counterpart.
 </aside>
 
 ### The TL;DR
 
 <ul class="tldr">
-  <li><strong>Meetings are not the problem — meeting <em>design</em> is.</strong> Duration, attendee count, and agenda clarity are the structural drivers of meeting quality.</li>
-  <li><strong>The best-performing meetings are focused, right-sized (5–8 people), and short (≤30 minutes).</strong> These are design choices made before the meeting begins, not a function of facilitator talent.</li>
+  <li><strong>Meeting <em>design</em> is what separates a good meeting from a bad one.</strong> Duration, attendee count, and agenda clarity are the structural drivers of meeting quality.</li>
+  <li><strong>The best-performing meetings are focused, right-sized (5–8 people), and short (≤30 minutes).</strong> Those are choices made before the meeting begins, and they matter more than facilitator talent.</li>
   <li><strong>Copilot reduces the anxiety loop</strong> that drives most in-meeting task-switching. The safety net of recap and follow makes informed absence a real option.</li>
-  <li><strong>The biggest gains come from defaults, not training.</strong> 25/50-minute meeting defaults, no-meeting blocks, and recurring-series audits change behaviour for people who never read the playbook.</li>
-  <li><strong>Managers are the highest-leverage point.</strong> Teams take their cues from how their manager runs meetings — visible behaviour change from leaders is the most credible signal that meeting culture is genuinely a priority.</li>
+  <li><strong>Defaults deliver bigger gains than training.</strong> 25/50-minute meeting defaults, no-meeting blocks, and recurring-series audits change behaviour for people who never read the playbook.</li>
+  <li><strong>Managers are the highest-leverage point.</strong> Teams take their cues from how their manager runs meetings, and visible behaviour change from leaders is the most credible signal that meeting culture is a priority.</li>
 </ul>
 
 <section id="part-1" class="part-head">
 <span class="part-kicker">Part 1</span>
-<h2>Best practices — before, during, and after</h2>
+<h2>Best practices before, during, and after</h2>
 </section>
 
 <h3>Not all meetings deserve a place in the calendar</h3>
@@ -66,7 +66,7 @@ For the *why* — meeting science, the multitasking taxonomy, the evidence on AI
 <div class="four-up reveal" markdown="1">
 
 **01 · Do I need to contribute?**
-<br>If not, you are an FYI recipient — not a required attendee. Ask the organiser to share the recap or mark yourself as a follower in Teams.
+<br>If not, you are an FYI recipient rather than a required attendee. Ask the organiser to share the recap or mark yourself as a follower in Teams.
 
 **02 · Is this a real-time conversation?**
 <br>If the purpose is information-sharing, async is almost always better. Suggest a recorded update or a shared document instead.
@@ -140,13 +140,13 @@ Aim for 5 to 8 attendees. Every person added increases cognitive cost and multit
 Build in natural transition time and structurally prevent back-to-back scheduling. Many recurring check-ins lose nothing when 60 minutes becomes 45.
 
 **03 · Give 24+ hours' notice.**
-Last-minute meetings disrupt focus time and signal poor planning. Short-notice rates are a quality signal worth tracking — a high proportion across a team indicates a reactive scheduling culture.
+Last-minute meetings disrupt focus time and signal poor planning. Short-notice rates are a quality signal worth tracking; a high proportion across a team indicates a reactive scheduling culture.
 
 </div>
 
 <aside class="callout reveal" markdown="1">
 <span class="callout-label">During the meeting</span>
-The facilitator owns the agenda, the time, and the quality of the discussion. The note-taker owns the action items. Where Copilot is available, the note-taking role can be substantially automated — freeing that person to contribute fully rather than transcribing.
+The facilitator owns the agenda, the time, and the quality of the discussion. The note-taker owns the action items. Where Copilot is available, the note-taking role can be substantially automated, freeing that person to contribute rather than transcribe.
 </aside>
 
 <aside class="callout reveal" markdown="1">
@@ -159,7 +159,7 @@ Every recurring series deserves a periodic review: <em>Is this still needed? At 
 <h2>Copilot as your meeting partner</h2>
 </section>
 
-<p>Copilot is not just a productivity feature — it addresses a structural driver of meeting dysfunction. Most in-meeting multitasking is driven by anxiety about what is building up elsewhere. Copilot monitors and summarises in the background, allowing full presence without that fear. The safety net is always there; the anxiety loop is broken.</p>
+<p>Copilot addresses a structural driver of meeting dysfunction. Most in-meeting multitasking comes from anxiety about what is building up elsewhere, and Copilot monitors and summarises in the background, so people can stay present without worrying about what they are missing.</p>
 
 <figure class="article-figure reveal">
 <svg viewBox="0 0 980 380" role="img" aria-labelledby="fig2-title fig2-desc">
@@ -206,7 +206,7 @@ Every recurring series deserves a periodic review: <em>Is this still needed? At 
     <text x="366" y="296" fill="#fff" font-size="17" font-weight="700">Intelligent Recap</text>
     <text x="366" y="324" fill="#FFF3DA" font-size="13">
       <tspan x="366" dy="0">AI notes, owners, chapter markers</tspan>
-      <tspan x="366" dy="16">— ready within minutes.</tspan>
+      <tspan x="366" dy="16">ready within minutes.</tspan>
     </text>
 
     <rect x="644" y="232" width="288" height="124" rx="12" fill="#B6722A"/>
@@ -225,16 +225,16 @@ Every recurring series deserves a periodic review: <em>Is this still needed? At 
 
 <p><strong>Intelligent Recap.</strong> After any recorded Teams meeting, Copilot generates a structured, AI-powered summary: key discussion points, attributed action items, and chapter markers with timestamps that let anyone jump to the relevant part. Notes are available within minutes. You no longer need to write up the meeting, sit through a recording, or rely on memory to reconstruct what was agreed.</p>
 
-<p><strong>Follow, don't attend.</strong> Instead of attending, you can mark yourself as "following" a meeting and receive the full recap automatically. This changes the calculus of attendance: if your role is to be informed of outcomes rather than to contribute, there is now a better option than attending. Meeting organisers can explicitly invite non-contributors as followers for large meetings — removing the social pressure to attend and giving people a legitimate, supported way to opt out.</p>
+<p><strong>Follow, don't attend.</strong> Instead of attending, you can mark yourself as "following" a meeting and receive the full recap automatically. This changes the calculus of attendance: if your role is to be informed of outcomes rather than to contribute, there is now a better option than attending. Meeting organisers can explicitly invite non-contributors as followers for large meetings, which removes the social pressure to attend and gives people a supported way to opt out.</p>
 
 <aside class="callout reveal" markdown="1">
 <span class="callout-label">Why it works</span>
-Most in-meeting multitasking is driven by three anxieties: <em>am I missing email?</em>, <em>am I missing a parallel meeting?</em>, and <em>am I missing context I'll need later?</em> Copilot addresses all three directly — drafting email faster, providing recaps for parallel meetings, and surfacing what was decided. It treats the cause, not just the symptom.
+Most in-meeting multitasking is driven by three anxieties: <em>am I missing email?</em>, <em>am I missing a parallel meeting?</em>, and <em>am I missing context I'll need later?</em> Copilot addresses all three by drafting email faster, providing recaps for parallel meetings, and surfacing what was decided. That treats the cause rather than the symptom.
 </aside>
 
 <aside class="callout reveal" markdown="1">
 <span class="callout-label">Deployment is not adoption</span>
-A Copilot licence does not automatically mean Copilot use. Recap adoption can vary by an order of magnitude between functions even where the licence is universal — see the companion brief, [**When AI Met the Meeting**]({{ site.baseurl }}/articles/when-ai-met-the-meeting/), for the field evidence. Closing that gap is what Part 3 below is about: managers as adoption multipliers, defaults as silent leverage, and the heaviest organisers as the most cost-effective intervention point.
+A Copilot licence does not automatically mean Copilot use. Recap adoption can vary by an order of magnitude between functions even where the licence is universal — see the companion brief, [**When AI Met the Meeting**]({{ site.baseurl }}/articles/when-ai-met-the-meeting/), for the field evidence. Part 3 covers how to close that gap: managers as adoption multipliers, defaults that shift behaviour without training, and the heaviest organisers as the most cost-effective intervention point.
 </aside>
 
 <section id="part-3" class="part-head">
@@ -242,42 +242,42 @@ A Copilot licence does not automatically mean Copilot use. Recap adoption can va
 <h2>Scaling culture change</h2>
 </section>
 
-<p>Individual habits matter — but lasting change requires systemic levers. The most effective programmes change the <em>environment</em>, not the people.</p>
+<p>Individual habits matter, but lasting change requires systemic levers. The most effective programmes change the <em>environment</em> rather than the people.</p>
 
 <h3>Three levers for organisation-wide change</h3>
 
 <div class="three-up reveal" markdown="1">
 
 **01 · No-meeting blocks.**
-Programmes such as Focus Fridays — or any designated no-meeting block — create structural space for deep work. They only succeed if organisers respect them, which makes manager buy-in essential and measurement a prerequisite. Viva Insights can track Friday meeting hours as the primary KPI.
+Programmes such as Focus Fridays, or any designated no-meeting block, create structural space for deep work. They only succeed if organisers respect them, which makes manager buy-in essential and measurement a prerequisite. Viva Insights can track Friday meeting hours as the primary KPI.
 
 **02 · Default meeting durations.**
 Configuring Outlook and Teams to default to 25- or 50-minute meetings costs nothing, requires no training, and has an immediate structural effect on everyone's calendar. Defaults influence behaviour even for people who never read the playbook.
 
 **03 · Top-organiser engagement.**
-In most organisations, the majority of meeting hours are generated by a relatively small number of people. Identifying and engaging the heaviest meeting organisers — particularly senior leaders — produces faster, more lasting impact than broad awareness campaigns. Use Viva Insights organiser data to find them.
+In most organisations, the majority of meeting hours are generated by a relatively small number of people. Identifying and engaging the heaviest meeting organisers, particularly senior leaders, produces faster and more lasting impact than broad awareness campaigns. Use Viva Insights organiser data to find them.
 
 </div>
 
 <h3>Managers are the highest-leverage point</h3>
 
-<p>Teams take their cues from how their manager behaves in meetings. If you start on time, end on time, share an agenda, and send a follow-up note, you set the standard for everyone around you. The reverse is equally true. Meeting culture flows downward — the most senior person in the room sets the norm, whether intentionally or not.</p>
+<p>Teams take their cues from how their manager behaves in meetings. If you start on time, end on time, share an agenda, and send a follow-up note, you set the standard for everyone around you. The reverse is equally true. Meeting culture flows downward, and the most senior person in the room sets the norm whether they intend to or not.</p>
 
 <aside class="callout reveal" markdown="1">
 <span class="callout-label">For managers</span>
-Use Viva Insights to share meeting patterns with your team — <em>not</em> as a surveillance tool, but as a shared reference point. <em>Which of our recurring meetings are running longest? Where is multitasking highest? What can we change together?</em> Data makes these conversations objective, depersonalised, and actionable in a way that is difficult to achieve without it.
+Use Viva Insights to share meeting patterns with your team as a shared reference point rather than a surveillance tool. <em>Which of our recurring meetings are running longest? Where is multitasking highest? What can we change together?</em> Data keeps these conversations objective and depersonalised.
 </aside>
 
-<h3>The most valuable — and most vulnerable — meeting</h3>
+<h3>The 1:1 is the most valuable meeting, and the easiest one to drop</h3>
 
-<p>The 1:1 format consistently produces the lowest multitasking of any meeting type <a href="#ref-3">[3]</a>. In a 1:1, both parties are immediately aware if attention drops; there is nowhere to hide. This built-in accountability makes it uniquely effective. <strong>1:1s with direct reports should be the last meetings dropped when calendar pressure builds, not the first.</strong></p>
+<p>The 1:1 format consistently produces the lowest multitasking of any meeting type <a href="#ref-3">[3]</a>. In a 1:1, both parties are immediately aware if attention drops; there is nowhere to hide, and that built-in accountability is what makes the format work. <strong>1:1s with direct reports should be the last meetings dropped when calendar pressure builds, not the first.</strong></p>
 
 <table class="is-wide reveal">
   <thead>
     <tr><th>Team signal in Viva Insights</th><th>What it usually means</th></tr>
   </thead>
   <tbody>
-    <tr><td>High multitasking hours</td><td>Likely too many large or long meetings — investigate structural drivers</td></tr>
+    <tr><td>High multitasking hours</td><td>Likely too many large or long meetings; investigate structural drivers</td></tr>
     <tr><td>Low focus time</td><td>Calendar over-fragmented; help protect uninterrupted blocks</td></tr>
     <tr><td>High conflicting meeting hours</td><td>Frequently double-booked; resolve before it shows as disengagement</td></tr>
     <tr><td>Declining 1:1 frequency</td><td>Connection risk; restore cadence before it shows in engagement scores</td></tr>
@@ -290,7 +290,7 @@ Use Viva Insights to share meeting patterns with your team — <em>not</em> as a
 <h2>Measure and improve</h2>
 </section>
 
-<p>Six metrics, tracked over time in Viva Insights, are enough to know whether meeting culture is improving — and whether the work to improve it is landing <a href="#ref-4">[4]</a>.</p>
+<p>Six metrics, tracked over time in Viva Insights, are enough to tell whether meeting culture is improving and whether the work to improve it is landing <a href="#ref-4">[4]</a>.</p>
 
 <figure class="article-figure reveal">
 <svg viewBox="0 0 980 420" role="img" aria-labelledby="fig3-title fig3-desc">
@@ -305,8 +305,8 @@ Use Viva Insights to share meeting patterns with your team — <em>not</em> as a
     <text x="68" y="148" fill="#11365A" font-size="17" font-weight="700">Meeting hours</text>
     <text x="68" y="178" fill="#1f2a33" font-size="13">
       <tspan x="68" dy="0">Hours per person per week.</tspan>
-      <tspan x="68" dy="16">The foundational signal — the</tspan>
-      <tspan x="68" dy="16">baseline for everything else.</tspan>
+      <tspan x="68" dy="16">The baseline that every other</tspan>
+      <tspan x="68" dy="16">signal is read against.</tspan>
     </text>
 
     <rect x="346" y="92" width="288" height="140" rx="12" fill="#FCEEEE" stroke="#E7C1BB"/>
@@ -323,8 +323,8 @@ Use Viva Insights to share meeting patterns with your team — <em>not</em> as a
     <text x="664" y="148" fill="#C79A3A" font-size="17" font-weight="700">Multitasking rate</text>
     <text x="664" y="178" fill="#1f2a33" font-size="13">
       <tspan x="664" dy="0">Meeting hours with parallel</tspan>
-      <tspan x="664" dy="16">email or chat. A design</tspan>
-      <tspan x="664" dy="16">problem, not a behaviour.</tspan>
+      <tspan x="664" dy="16">email or chat. Usually a</tspan>
+      <tspan x="664" dy="16">design problem.</tspan>
     </text>
 
     <rect x="48" y="248" width="288" height="140" rx="12" fill="#E9F4EC" stroke="#BCDCC6"/>
@@ -350,8 +350,8 @@ Use Viva Insights to share meeting patterns with your team — <em>not</em> as a
     <text x="664" y="304" fill="#11365A" font-size="16" font-weight="700">Late join / late end frequency</text>
     <text x="664" y="334" fill="#1f2a33" font-size="13">
       <tspan x="664" dy="0">Late starts and overruns.</tspan>
-      <tspan x="664" dy="16">Reveals whether norms hold</tspan>
-      <tspan x="664" dy="16">in practice, not just policy.</tspan>
+      <tspan x="664" dy="16">Shows whether norms hold</tspan>
+      <tspan x="664" dy="16">in practice as well as policy.</tspan>
     </text>
   </g>
 </svg>
@@ -360,17 +360,17 @@ Use Viva Insights to share meeting patterns with your team — <em>not</em> as a
 
 <section id="start-this-week" class="part-head">
 <span class="part-kicker">Start this week</span>
-<h2>Three actions that need no approval, no budget, no new tools</h2>
+<h2>Three actions you can take without approval, budget, or new tools</h2>
 </section>
 
 <aside class="callout is-action reveal" markdown="1">
 <span class="callout-label">Start this week</span>
 1. **Audit one recurring meeting you own.** Pick the longest-running. Ask the group: *Is this still necessary? At this frequency? With everyone currently invited?* One meeting changed per month is twelve improved per year.
-2. **Change your Outlook defaults to 25 / 50 minutes.** Under a minute to implement (File &gt; Options &gt; Calendar). Every new meeting you create will default to a shorter duration — and create natural gaps between calls.
+2. **Change your Outlook defaults to 25 / 50 minutes.** Under a minute to implement (File &gt; Options &gt; Calendar). Every new meeting you create will default to a shorter duration and leave natural gaps between calls.
 3. **Turn on Copilot Intelligent Recap for your next recurring meeting.** Share the output with attendees and at least one "follower" who didn't attend. This sets the norm that non-attendees can stay fully informed without being in the room.
 </aside>
 
-<p><strong>A coda.</strong> Meeting culture does not change because a policy is published. It changes because the calendar changes — defaults shift, recurring series get audited, recaps land in people's inboxes, and managers behave differently in the meetings they run. AI is not the fix. It is the amplifier. The choice is which culture you ask it to scale.</p>
+<p><strong>A closing note.</strong> Meeting culture does not change because a policy is published. It changes when the calendar changes: defaults shift, recurring series get audited, recaps land in people's inboxes, and managers run their own meetings differently. Copilot amplifies whichever culture it is dropped into, so start with the three actions above and measure the six signals in Part 4.</p>
 
 <section id="references" class="references">
 <h2>References</h2>


### PR DESCRIPTION
## Summary

An editorial pass on **The Meeting Effectiveness Playbook** (`_pages/meeting-effectiveness-playbook.md`) to improve the language and styling. The content, argument, structure, figures, metrics and references are unchanged — this is a prose-only change.

The playbook's substance is good, but the writing had picked up a few stylistic habits that made it read as generic rather than considered. This tidies those up while keeping the existing voice.

## What changed

| Area | Before | After |
|---|---|---|
| Em-dashes | 9 in body prose | 1 (plus the typographic ones in figure captions and table labels) |
| Opening line | "This is the operating manual." | Lead now goes straight to what the playbook covers |
| Binary contrasts | "Meetings are not the problem — meeting *design* is.", "The biggest gains come from defaults, not training.", "A design problem, not a behaviour." | Stated directly as positive claims |
| Closing paragraph | "AI is not the fix. It is the amplifier. The choice is which culture you ask it to scale." | Ends on the concrete next actions and the six signals in Part 4 |
| Qualifiers | "genuinely a priority", "legitimate, supported way", "uniquely effective", "actionable in a way that is difficult to achieve without it" | Trimmed |
| Headings | "The most valuable — and most vulnerable — meeting", "Three actions that need no approval, no budget, no new tools" | "The 1:1 is the most valuable meeting, and the easiest one to drop", "Three actions you can take without approval, budget, or new tools" |
| Front matter | `description` and `dek` | Same content, em-dashes removed |

Three SVG figure labels were reworded for the same reasons (Figure 2 recap caption, Figure 3 metrics 01, 03 and 06). Line lengths were kept within the existing box widths.

## What did *not* change

- Section order, headings hierarchy, anchors and the in-article contents nav
- All figures, SVG layout, colours and dimensions
- All tables, data, metric definitions and thresholds
- All references and external links
- British spelling and the overall register

## Review notes

The diff is 35 lines changed, mostly one-for-one paragraph replacements, so a side-by-side read of the rendered page against production should be straightforward. Worth a specific check on the three SVG figures to confirm no text overflow.
