### PR TITLE
feat(frontier): add AI-guided Copilot dashboard journeys

### DIFF
--- a/.github/scripts/check_prompt_drift.py
+++ b/.github/scripts/check_prompt_drift.py
@@ -49,6 +49,8 @@ MAPPING: dict[str, str] = {
     "copilot-adoption/copilot-causal-toolkit.md": "frontier-analytics-prompt-causal-toolkit.md",
     "purview-augmentation/audit-log-parsing.md": "frontier-analytics-prompt-audit-parsing.md",
     "purview-augmentation/agent-usage-analysis.md": "frontier-analytics-prompt-agent-usage.md",
+    "copilot-dashboards/consumption-dashboard.md": "frontier-analytics-prompt-consumption-dashboard.md",
+    "copilot-dashboards/developer-experience-dashboard.md": "frontier-analytics-prompt-developer-experience-dashboard.md",
 }
 
 # Prompt cards that are intentionally repo-only, with no site-page mirror.
@@ -137,6 +139,14 @@ def main() -> int:
                 f"{pair_label}: 'Quick prompt (short version)' content differs "
                 "between the prompt card and the site page. They must match exactly."
             )
+
+        # New dashboard journeys share one workflow; their full entry prompts
+        # must not drift even though resource links differ on GitHub and Pages.
+        if card_rel.startswith("copilot-dashboards/"):
+            prompt_card = section_text(card_text, "Prompt")
+            prompt_page = section_text(page_text, "Prompt")
+            if not prompt_card or prompt_card != prompt_page:
+                hard_failures.append(f"{pair_label}: full Prompt sections must match exactly.")
 
         for keyword in PARITY_KEYWORDS:
             in_card = keyword in card_text

--- a/_includes/custom-navigation.html
+++ b/_includes/custom-navigation.html
@@ -171,6 +171,8 @@
               <a href="{{ site.baseurl }}/frontier-analytics/">🌐 Frontier</a>
               <a href="{{ site.baseurl }}/frontier-analytics-prompts/">📝 Prompt library</a>
               <a href="{{ site.baseurl }}/frontier-analytics-schemas/">📋 Schema docs</a>
+              <a href="{{ site.baseurl }}/frontier-analytics-prompt-consumption-dashboard/">📊 Build a consumption dashboard</a>
+              <a href="{{ site.baseurl }}/frontier-analytics-prompt-developer-experience-dashboard/">📊 Build a developer dashboard</a>
             </div>
             <div class="vi-mega-col">
               <h3>Copilot adoption</h3>

--- a/_pages/copilot-dashboards.md
+++ b/_pages/copilot-dashboards.md
@@ -36,9 +36,12 @@ Separate consumption volume from consumption mix: token concentration and percen
 [Get source](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-r/copilot-consumption-ways-of-working-simulation.Rmd) ·
 [Setup guide](#build-with-your-own-data)
 
+**[Build or customise with AI]({{ site.baseurl }}/frontier-analytics-prompt-consumption-dashboard/)**:
+reproduce the demo or build a scoped credits report with an agent and reusable R code.
+
 [![Consumption report overview]({{ site.baseurl }}/assets/images/reports/copilot-consumption-overview.png)]({{ site.baseurl }}/examples/utility-r/copilot-consumption-ways-of-working-simulation.html)
 
-**Required queries:** Consumption query for credits, tokens, and delegated task types, joined with a Person Query for collaboration and network metrics. See the [AI cost query documentation](https://learn.microsoft.com/en-us/viva/insights/advanced/analyst/ai-cost-query) for schema and access details.
+**Demo inputs:** Synthetic credit, token and task-type data alongside Person Query and network fixtures. The [public Consumption schema](https://learn.microsoft.com/en-us/viva/insights/advanced/analyst/ai-cost-query) establishes credits and sessions, but not this demo's token/task-type fields. The AI-guided real-data path therefore builds a narrower credits-only report and labels unsupported panels.
 
 **Interpretation:** Associations only. Credit intensity is a cost-mix measure, not a measure of value or quality. Concentration curves and banded percentiles help describe skewed consumption without relying on an average.
 
@@ -58,6 +61,9 @@ Establish a baseline of developer working conditions alongside GitHub and Micros
 **[View demo]({{ site.baseurl }}/examples/utility-r/github-copilot-developer-productivity-simulation.html)** ·
 [Get source](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-r/github-copilot-developer-productivity-simulation.Rmd) ·
 [Setup guide](#build-with-your-own-data)
+
+**[Build or customise with AI]({{ site.baseurl }}/frontier-analytics-prompt-developer-experience-dashboard/)**:
+reproduce the synthetic reference or assess real inputs. No verified real GitHub adapter is supplied yet.
 
 [![Developer experience report focus and coordination]({{ site.baseurl }}/assets/images/reports/github-copilot-devex-focus.png)]({{ site.baseurl }}/examples/utility-r/github-copilot-developer-productivity-simulation.html)
 
@@ -79,8 +85,8 @@ The developer demo uses an **extended illustrative schema**, not a drop-in flexi
 The demos need only a browser. To render or adapt the templates, use **R**, **Pandoc**, **R Markdown**, and **flexdashboard**. There is no Python version of these templates.
 
 1. **Get the files.** Start with the report source linked above. For Developer Experience, also get [github-developer-experience-helpers.R](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-r/github-developer-experience-helpers.R) and [render-github-developer-experience.R](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-r/render-github-developer-experience.R), keeping the repository folder structure.
-2. **Render the synthetic example first.** Dependencies include `vivainsights`, `dplyr`, `tidyr`, `ggplot2`, `scales`, `stringr`, `flexdashboard`, `knitr`, and `rmarkdown`. Follow the [template setup guide](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-r/copilot-consumption-github-demo-reports.md) for rendering instructions and simulated input contracts.
-3. **Adapt the inputs.** Use the guide to replace the simulation block with your query exports. Check query schemas, join keys, date ranges, eligibility, and coverage before interpreting results.
+2. **Render the synthetic example first.** Dependencies include `vivainsights`, `dplyr`, `tidyr`, `ggplot2`, `ggrepel`, `scales`, `stringr`, `flexdashboard`, `knitr`, and `rmarkdown`. The AI-guided journeys copy the required fixtures and source into an isolated output folder before rendering.
+3. **Adapt only supported inputs.** Use the [Consumption journey]({{ site.baseurl }}/frontier-analytics-prompt-consumption-dashboard/) for the scoped credits adapter. Use the [Developer Experience journey]({{ site.baseurl }}/frontier-analytics-prompt-developer-experience-dashboard/) for a real-input readiness assessment. Verify contracts before replacing any simulation; do not assume a CSV with similar headers is equivalent.
 4. **Review before sharing.** Update simulation labels and methodology to describe your actual inputs. Apply your organization's privacy requirements and retain the distinction between association and causation. Do not put customer exports in this sample repository or in shareable HTML.
 
 [Read the full template setup guide](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-r/copilot-consumption-github-demo-reports.md)

--- a/_pages/frontier-analytics-prompt-consumption-dashboard.md
+++ b/_pages/frontier-analytics-prompt-consumption-dashboard.md
@@ -1,0 +1,108 @@
+---
+layout: page
+title: "Build with AI: Consumption Dashboard"
+eyebrow: "Frontier"
+description: "Reproduce the Consumption demo or build a scoped credits dashboard with an AI coding agent and reusable R code."
+permalink: /frontier-analytics-prompt-consumption-dashboard/
+---
+{% include prompt-styles.html %}
+
+[Back to Prompt Library]({{ site.baseurl }}/frontier-analytics-prompts/) · [View dashboard examples]({{ site.baseurl }}/copilot-dashboards/)
+
+## Purpose
+
+Reproduce the synthetic seven-page R demo, then customise it or build a narrower
+credits dashboard from documented Consumption exports without starting over.
+
+## Audience
+
+People analytics practitioners and analysts exploring Copilot consumption.
+
+## When to use
+
+Choose this journey for the Consumption query, not the general Person Query
+adoption dashboard. A coding agent can follow the workflow without installing
+a skill; frequent users can install the optional dashboard skill.
+
+## Required inputs
+
+- A local checkout of `microsoft/viva-insights-sample-code` containing the
+  shared runner at `frontier-analytics/starter-kits/copilot-query-dashboard/`.
+- R and the dependencies listed by the runner; Pandoc for the reference demo.
+- Demo: supplied synthetic fixture files only.
+- Real: locally extracted activity and people-metadata CSVs, query grain,
+  date window, chosen HR group, mapping evidence and privacy requirements.
+
+## Assumptions
+
+The demo's tokens and delegated task types are illustrative. The real v1
+adapter supports documented credit consumption, not the full demo. Missing
+tokens do not block a credits-only report; they exclude token-based panels.
+
+## Recommended output
+
+A self-contained HTML report, reproducible config and source, local provenance,
+validation summary, and explicit supported/excluded analyses. Real data stays
+outside the repository and is never pasted into the prompt.
+
+## Quick prompt (short version)
+
+```text
+Help me reproduce or customise the Consumption and Ways of Working dashboard.
+Recover choices already supplied, then ask only for missing checkout, demo versus real mode, output folder and intended changes.
+Read frontier-analytics/skills/viva-insights-copilot-dashboards/SKILL.md in that checkout as workflow instructions, without requiring skill installation.
+Use its Consumption manifest and the shared R runner; do not regenerate the dashboard from scratch.
+For real exports, inspect locally, show supported and excluded panels, and get my approval before building.
+Do not invent tokens, licensing, coverage, identity mappings or causal conclusions.
+```
+
+## Prompt
+
+```text
+Build a Consumption dashboard using the local microsoft/viva-insights-sample-code checkout.
+Recover any inputs I already supplied. Use prompt mode for the remaining choices:
+checkout path, demo or real, audience, input files, output directory, period, grouping,
+privacy threshold (at least 10 distinct people), and requested customisations.
+
+Read frontier-analytics/skills/viva-insights-copilot-dashboards/SKILL.md and only
+the selected mode plus Consumption manifest. Read the shared query contract it links.
+Use frontier-analytics/starter-kits/copilot-query-dashboard/README.md for the config
+schema and dashboard.R commands. Record the checkout revision and source fingerprints.
+
+For demo mode, reproduce the reference using copied synthetic fixtures in a new output
+workspace. Keep the fixed seed/window and synthetic labels. Do not alter canonical source files.
+For real mode, inspect the extracted CSVs locally and return bounded schema summaries,
+not rows or identifiers. Verify keys, grain, units and historical metadata joins.
+Present supported/excluded panels and mapping evidence; wait for my approval to build.
+Support a credits-only output when tokens or task types are unavailable. Do not generate
+synthetic replacements, infer licences from activity, or sum policy limits.
+
+Use the existing R code. Check dependencies before requesting installation. Do not read
+the generated HTML or whole CSVs into model context. No individual rankings or unsupported
+productivity, ROI, quality, burnout or causal claims. Suppress small groups in every output.
+After two unsuccessful repairs of the same failure, stop with the specific blocker.
+Return the local report, rerun command, config/provenance and limitations. Do not publish.
+```
+
+## Adaptation notes
+
+Start with "change the colours and section order" for a presentation-only
+iteration. Changing dates, grouping or sources requires renewed data and
+privacy checks. Person Query associations require a separately verified adapter.
+
+## Common failure modes
+
+- **Assuming credit exports contain tokens:** build only supported panels.
+- **Joining service rows directly to Person Query:** aggregate to compatible
+  person-period grain first; a joined real-data adapter is not supplied in v1.
+- **Rendering in the examples folder:** use the isolated runner workspace.
+- **Calling credits money or value:** retain credit units and descriptive claims.
+
+## Resources
+
+- [Starter kit](https://github.com/microsoft/viva-insights-sample-code/tree/main/frontier-analytics/starter-kits/consumption-dashboard)
+- [Shared runner](https://github.com/microsoft/viva-insights-sample-code/tree/main/frontier-analytics/starter-kits/copilot-query-dashboard)
+- [Optional skill installation](https://github.com/microsoft/viva-insights-sample-code/blob/main/frontier-analytics/skills/README.md#dashboard-skill-installation)
+- [Public Consumption schema](https://learn.microsoft.com/en-us/viva/insights/advanced/analyst/ai-cost-query)
+
+{% include responsible-use.html %}

--- a/_pages/frontier-analytics-prompt-dashboard.md
+++ b/_pages/frontier-analytics-prompt-dashboard.md
@@ -47,7 +47,7 @@ After exporting a person query with Copilot activity metrics spanning at least 8
 - Data is at person-week granularity
 - `PersonId` is a consistent anonymized identifier
 - `MetricDate` is a date field representing the start of each week
-- Rows with missing Copilot metric values likely represent unlicensed users
+- Licensing and coverage require explicit evidence; missing activity alone is inconclusive
 - The `vivainsights` R or Python package is available in the environment
 
 ## Recommended output
@@ -62,10 +62,10 @@ Use this shorter prompt for a fast first pass that adapts to your data.
 Help me create a self-contained static HTML dashboard for people analytics and IT leaders that summarizes Copilot adoption trends and group differences from a Viva Insights person query export.
 Start by loading the actual CSV and printing the row count, column names, data types, date range, and number of unique people, then map the real metric and HR columns from what is present.
 Do not assume exact field names, and ask me to confirm the primary activity metric or any missing HR columns if the mapping is ambiguous.
-Separate licensed users from active users before calculating anything, treating missing Copilot metrics as unlicensed unless the data clearly indicates otherwise.
+Separate licensed users from active users using explicit licensing and coverage evidence. If those are unavailable, show observed activity and mark adoption rates unavailable; do not infer licensing from activity or missingness.
 Build weekly adoption metrics using distinct people per week, then add the most useful group views from the available HR attributes.
 The output must be a single self-contained static HTML file with inline assets and no server or external dependencies.
-Suppress any group with fewer than about 5 people, and note any skipped charts or missing segments.
+Suppress any group with fewer than 10 distinct people, or the stricter organisational minimum, and withhold breakdowns that could reveal suppressed cells. Do not publish individual rankings. Note skipped charts or missing segments.
 At the end, list any assumptions you made about metric selection, licensing logic, or field mappings.
 ```
 
@@ -83,12 +83,12 @@ DATA LOADING AND VALIDATION
 1. Load the person query CSV using `import_query()` from the `vivainsights` library (R or Python). This handles variable name cleaning and type parsing automatically.
 2. Ensure PersonId is treated as a string and MetricDate is parsed as a date type.
 3. Run `extract_hr(df)` from the `vivainsights` library to identify the available HR / organizational attribute columns in the data. Use the returned list of HR attributes for all segmentation breakdowns instead of hard-coding column names like Organization, FunctionType, or LevelDesignation.
-4. Verify the panel structure: each row should represent a unique PersonId × MetricDate combination. If there are duplicates, flag them and keep the first occurrence.
+4. Verify the panel structure: each row should represent a unique PersonId × MetricDate combination. If there are duplicates, report their count and stop for an explicit resolution rule.
 5. Print the shape of the data, the date range covered, and the number of unique persons.
 6. List all column names so I can verify the Copilot metric columns and HR attribute columns match what is expected. Identify Copilot metric columns by checking for columns containing the word "Copilot" in their name. Reference the taxonomy at https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/example-data/copilot-metrics-taxonomy.csv to classify and validate the detected metrics. Use `Total_Copilot_actions_taken` as the primary activity proxy **if it is present** — validate it against the taxonomy first, as it may not capture every Copilot surface or app.
 
 IDENTIFYING LICENSED USERS
-6. A user is considered "Copilot-licensed" in a given week using this rule, in order. If an enabled-days column is present (for example `Total_Copilot_enabled_days`), the user is licensed when that column is greater than zero for the week. Otherwise, the user is licensed if they have a non-null, non-zero value in at least one Copilot metric column for that week. Create a boolean column `is_licensed` to flag these rows.
+6. Use a documented enabled-days column (for example `Total_Copilot_enabled_days > 0`) or explicit licence records for the period. If unavailable, retain unknown licensing and omit adoption rates; do not infer licences from activity. Create `is_licensed` with unknown values retained. Confirm coverage before filling absent activity with zero.
 7. Also flag "active" users: licensed users who have Total_Copilot_actions_taken > 0 (the primary activity metric) in that week. Create a boolean column `is_active`.
 8. Print a summary: total person-weeks, licensed person-weeks, active person-weeks.
 
@@ -110,8 +110,8 @@ SEGMENTATION METRICS
     d. Mean Total_Copilot_actions_taken per active user
 12. Store each in a separate DataFrame (e.g., `org_summary`, `function_summary`, `level_summary`).
 
-TOP USERS TABLE
-13. Compute a "top users" table: for each PersonId, calculate total Total_Copilot_actions_taken across all weeks, total active weeks, and average Total_Copilot_actions_taken per active week. Rank by total actions descending. Keep the top 20. Include their HR attributes for context.
+GROUP SUMMARY TABLE
+13. Compute activity summaries by an approved HR group using distinct people and the declared time window. Apply privacy suppression to every cell and omit the entire breakdown if remaining cells or totals could reveal a suppressed value. Do not publish person rows.
 
 SUMMARY STATISTICS PANEL
 14. Calculate overall summary statistics for the dashboard header:
@@ -139,7 +139,7 @@ DASHBOARD GENERATION
        - Grouped bar chart: Adoption rate by FunctionType (latest 4-week average)
        - Grouped bar chart: Adoption rate by LevelDesignation (latest 4-week average)
        - Heatmap: Adoption rate by Organization × week (if number of orgs <= 15)
-    e. TOP USERS TABLE: HTML table of top 20 users from step 13.
+    e. GROUP SUMMARY TABLE: privacy-protected aggregate table from step 13, with no identifiers.
     f. METHODOLOGY NOTE: Brief paragraph explaining how adoption rate is calculated, what "licensed" and "active" mean, and the data source.
 
 17. Style the HTML with a clean, professional design. Use a sans-serif font, consistent color palette, and adequate whitespace. The dashboard should look presentable when opened in a browser.
@@ -148,18 +148,19 @@ DASHBOARD GENERATION
 
 IMPORTANT NOTES
 - Do NOT create interactive plots that require a running server (no plotly, no bokeh server). Static charts embedded in the RMarkdown/Jupyter output are preferred.
-- Handle missing values gracefully: NaN in Copilot columns means the user is unlicensed that week.
+- Preserve unknown coverage and eligibility. NaN is not proof of an unlicensed user.
+- Omit metrics without verified inputs, including assisted hours or licensing-dependent summaries. Describe skipped panels rather than estimating missing values.
 - If any HR attribute column is missing from the data, skip that segmentation chart and note it.
 - Use the `vivainsights` package (R or Python) for data loading (`import_query()`) and HR attribute discovery (`extract_hr()`). Use ggplot2 (R) or matplotlib/seaborn (Python) for charting.
 - All charts should have clear titles, axis labels, and legends.
-- If any segment has fewer than 5 users, suppress it from charts to protect privacy.
+- Use at least 10 distinct people per published group, or the stricter organisational minimum.
 ```
 
 ## Adaptation notes
 
 - The `extract_hr()` function auto-detects organizational attributes, so you typically do not need to manually specify HR column names. If your data has custom attribute columns that `extract_hr()` does not detect, add an instruction specifying them.
 - If your data is at person-day granularity, add an instruction: _"Aggregate person-day data to person-week by summing Copilot metrics per PersonId per week."_
-- For smaller organizations, increase the privacy threshold (e.g., from 5 to 10 users per segment) or remove segmentation breakdowns entirely.
+- Apply at least 10 distinct people per group, increase this if required by organisational policy, or omit segmentation entirely.
 - Add custom Copilot metrics by extending the list in step 5 (e.g., `Copilot_Edited_Hours`, `Copilot_Rewritten_Hours`).
 - If you prefer R over Python, add _"Use R with ggplot2 and R Markdown"_ at the start of the prompt.
 

--- a/_pages/frontier-analytics-prompt-developer-experience-dashboard.md
+++ b/_pages/frontier-analytics-prompt-developer-experience-dashboard.md
@@ -1,0 +1,108 @@
+---
+layout: page
+title: "Build with AI: Developer Experience Dashboard"
+eyebrow: "Frontier"
+description: "Reproduce and customise the developer demo with an AI coding agent, or assess real GitHub query inputs without assuming an export schema."
+permalink: /frontier-analytics-prompt-developer-experience-dashboard/
+---
+{% include prompt-styles.html %}
+
+[Back to Prompt Library]({{ site.baseurl }}/frontier-analytics-prompts/) · [View dashboard examples]({{ site.baseurl }}/copilot-dashboards/)
+
+## Purpose
+
+Reproduce and customise the synthetic developer dashboard with its existing R
+implementation, and assess real GitHub query inputs without guessing their contract.
+
+## Audience
+
+Engineering managers and people analytics practitioners studying working
+conditions alongside GitHub and Microsoft 365 Copilot use.
+
+## When to use
+
+Choose this journey for the Developer Experience reference report, not direct
+GitHub API analytics or an evaluation of developer productivity.
+
+## Required inputs
+
+- A local sample-code checkout containing the shared dashboard runner.
+- R and the dependencies listed by the runner; Pandoc for demo rendering.
+- Demo: no customer files; the copied helper creates synthetic data.
+- Real readiness assessment: approved local CSVs and available documentation
+  for grain, identity, metrics, eligibility and coverage.
+
+## Assumptions
+
+The demo uses an extended illustrative schema. M365 feature actions and
+eligibility/completeness flags are not a verified flexible-query export.
+Real GitHub data can be inspected, but v1 has no verified real build adapter.
+
+## Recommended output
+
+Demo mode produces a self-contained HTML report, copied source and provenance.
+Real mode produces an input-readiness assessment and missing-evidence list;
+it does not promise a complete report.
+
+## Quick prompt (short version)
+
+```text
+Help me reproduce or customise the Developer Experience and Copilot dashboard.
+Recover choices already supplied, then ask only for missing checkout, demo versus real mode, output folder and intended changes.
+Read frontier-analytics/skills/viva-insights-copilot-dashboards/SKILL.md in that checkout as workflow instructions, without requiring skill installation.
+Use its GitHub manifest and shared R runner; preserve coverage, privacy and synthetic labels.
+For real GitHub files, inspect only and explain the missing contract evidence; v1 has no verified real build adapter.
+Do not infer productivity, code quality, burnout, licensing or non-use from activity alone.
+```
+
+## Prompt
+
+```text
+Use the Developer Experience and Copilot reference in my local sample-code checkout.
+Recover choices already supplied, then use prompt mode for checkout/output locations,
+demo or real, audience, available files, period, grouping, privacy policy and intended changes.
+
+Read frontier-analytics/skills/viva-insights-copilot-dashboards/SKILL.md, its selected mode
+and GitHub manifest, and the shared analytical contract. Use the shared runner README
+at frontier-analytics/starter-kits/copilot-query-dashboard/ for exact commands/config.
+
+In demo mode, reproduce the copied Rmd/helper in an isolated workspace. Keep the seed,
+synthetic window, full developer baseline, eligibility and coverage distinctions.
+In real mode, run bounded local inspection. Identify source grain, join keys, units,
+coverage, licence evidence and model/language allocation periods. Headers alone do not
+verify semantics. Return supported observations and missing evidence for a future adapter.
+Do not source the synthetic helper on real inputs or bypass the unsupported-build gate.
+
+For customisation, edit the copied source, not bundled HTML or the canonical example.
+Presentation changes should preserve aggregate values. Population or metric changes
+require renewed inspection and my approval. No arbitrary duplicate removal, fuzzy
+employee joins, individual rankings or converting unresolved coverage to zero.
+Keep at least 10 distinct people per published group or a stricter organisational rule.
+Do not interpret acceptance as quality, available time as coding, or after-hours as burnout.
+
+Record revision, inputs and configuration. Avoid loading whole CSVs or generated HTML
+into model context. After two unsuccessful repairs of one failure, report the blocker.
+Return the report or readiness assessment, rerun command and limitations; do not publish.
+```
+
+## Adaptation notes
+
+Try changing the panel order or explanatory language on the synthetic demo
+first. Real-data support needs a source contract and a separately reviewed
+adapter. Do not rename public GitHub API fields into an assumed Viva contract.
+
+## Common failure modes
+
+- **Missing activity becomes zero:** require independent coverage and eligibility.
+- **Only Copilot users form the baseline:** retain the full developer population.
+- **Full-window mixes become weekly trends:** preserve their actual period.
+- **Demo runs over customer data:** use distinct modes and output workspaces.
+
+## Resources
+
+- [Starter kit](https://github.com/microsoft/viva-insights-sample-code/tree/main/frontier-analytics/starter-kits/developer-experience-dashboard)
+- [Shared runner](https://github.com/microsoft/viva-insights-sample-code/tree/main/frontier-analytics/starter-kits/copilot-query-dashboard)
+- [Optional skill installation](https://github.com/microsoft/viva-insights-sample-code/blob/main/frontier-analytics/skills/README.md#dashboard-skill-installation)
+- [Synthetic schema manifest](https://github.com/microsoft/viva-insights-sample-code/blob/main/examples/utility-r/_data/github/README.md)
+
+{% include responsible-use.html %}

--- a/_pages/frontier-analytics-prompts.md
+++ b/_pages/frontier-analytics-prompts.md
@@ -37,6 +37,16 @@ Each prompt card includes the purpose, required inputs, assumptions, the full pr
 | [Executive PowerPoint Deck]({{ site.baseurl }}/frontier-analytics-prompt-powerpoint/) | Generate an exec-ready 10–15 page PowerPoint deck with editable native charts. |
 | [Copilot Causal Toolkit]({{ site.baseurl }}/frontier-analytics-prompt-causal-toolkit/) | Run a causal inference analysis using the Copilot Causal Toolkit, then interpret results for senior leadership. Two prompts: one to run the analysis, one to interpret outputs. |
 
+### Query dashboards
+
+Start with the existing R reports and let an agent guide the next step. These
+journeys work with a pasted prompt or the optional dashboard skill.
+
+| Prompt Card | Description |
+|---|---|
+| [Consumption Dashboard]({{ site.baseurl }}/frontier-analytics-prompt-consumption-dashboard/) | Reproduce the synthetic demo or build a scoped credits report from documented exports. |
+| [Developer Experience Dashboard]({{ site.baseurl }}/frontier-analytics-prompt-developer-experience-dashboard/) | Reproduce/customise the demo or assess real GitHub input readiness; no verified real adapter in v1. |
+
 ### Purview Augmentation
 
 | Prompt Card | Description |

--- a/_pages/frontier-analytics-schemas.md
+++ b/_pages/frontier-analytics-schemas.md
@@ -15,6 +15,7 @@ For authoritative and up-to-date metric definitions and column references, see:
 
 **On this page:**
 
+- [Consumption and GitHub queries](#consumption-and-github-queries) — Documented versus illustrative inputs, and supported AI-guided workflows.
 - [Person Query — Key Concepts](#person-query-key-concepts) — Panel structure, licensing logic, and what to watch for.
 - [Purview Audit Logs — Key Concepts](#purview-audit-log-key-concepts) — Structure, the AuditData column, and data quality.
 - [Join Patterns](#join-patterns) — How to join person query data with Purview audit logs, external HR data, and license records.
@@ -28,6 +29,21 @@ For authoritative and up-to-date metric definitions and column references, see:
 - [vivainsights Python package](https://microsoft.github.io/vivainsights-py/)
 
 ---
+
+## Consumption and GitHub queries
+
+These are not interchangeable with a Person Query.
+
+| Source | Contract boundary | Guided journey |
+|---|---|---|
+| Consumption | The public export has activity by person/service/date and people metadata joined through `PeopleHistoricalId`. Confirm day/week/month grouping. Credits and sessions do not establish tokens, task types or monetary value. | [Build a Consumption dashboard]({{ site.baseurl }}/frontier-analytics-prompt-consumption-dashboard/) |
+| GitHub demo | The source manifest is an extended synthetic schema, including illustrative M365 activity and coverage flags. A real GitHub export adapter is not verified in v1. | [Build a Developer Experience dashboard]({{ site.baseurl }}/frontier-analytics-prompt-developer-experience-dashboard/) |
+
+Read the [shared query contract](https://github.com/microsoft/viva-insights-sample-code/blob/main/frontier-analytics/skills/viva-insights-analysis/reference/copilot-query-contracts.md)
+for keys, units, coverage, privacy and interpretation rules, and the
+[public Consumption documentation](https://learn.microsoft.com/en-us/viva/insights/advanced/analyst/ai-cost-query)
+for its current export schema. Missing fields exclude panels; agents must not
+generate synthetic replacements in a real-data run.
 
 ## Person Query — Key Concepts {#person-query-key-concepts}
 
@@ -59,11 +75,12 @@ This distinction is critical for any Copilot adoption analysis:
 
 | Status | Meaning | How to detect |
 |--------|---------|---------------|
-| **Unlicensed** | User does not have a Copilot license | All Copilot columns are `null` / `NA` |
-| **Licensed but inactive** | User has a license but did not use Copilot | Copilot columns contain `0` values |
-| **Active** | User has a license and used Copilot | Copilot activity metric > 0 |
+| **Unlicensed** | User does not have a Copilot license | Explicit licence evidence for the period |
+| **Licensed but inactive** | User has a license but did not use Copilot | Confirmed licence, complete coverage and observed zero activity |
+| **Active** | Observed use of the selected Copilot metric | Verified activity metric > 0; licence status is a separate attribute |
+| **Unknown** | Eligibility or observation coverage is unresolved | Retain separately; do not infer from absence |
 
-> **Critical:** `null` ≠ `0` in Copilot columns. Replacing `NA` with `0` conflates unlicensed users with inactive licensed users, which inflates denominators and produces misleading adoption rates.
+> **Critical:** `null` is not `0`, and neither establishes licensing by itself. Use documented enabled-days or licence records and coverage evidence. If a denominator is unknown, report observed activity and omit adoption rates.
 
 ---
 
@@ -127,8 +144,8 @@ Stack (concatenate) exports vertically using `PersonId` as the key. Check for du
 The key challenge is that person query data uses an anonymized `PersonId` while Purview uses `UserId` (UPN/email). These are **not the same identifier**.
 
 **Mapping options:**
-- **Mapping table from Viva Insights admin** (preferred) — a direct `PersonId` → UPN lookup. Normalize keys (lowercase, strip whitespace) before joining.
-- **Fuzzy join on HR attributes** (fallback) — match using shared organizational attributes. Less reliable and should be used with caution.
+- **Authorised mapping table** — a verified `PersonId` → UPN lookup where available. Apply only contract-approved normalisation to UPNs; preserve opaque PersonIds exactly.
+- **No authorised identity bridge:** stop the person-level join; shared HR attributes are not unique identities and must not be used for fuzzy employee matching.
 
 **Time alignment:** Person query data is weekly; Purview logs are event-level. Aggregate audit events to the person-week level before joining. Ensure both use the same week-start day (typically Monday).
 
@@ -141,7 +158,7 @@ Both follow the same pattern: you need a mapping table to link the anonymized `P
 
 ### Checklist for joins
 
-- Identify and normalize join keys on both sides (lowercase, strip whitespace)
+- Identify join keys and apply only contract-approved normalisation; preserve opaque IDs exactly
 - Verify cardinality: is the join 1:1, 1:many, or many:many?
 - Align time granularity: aggregate event-level data to the target period before joining
 - Check join match rate: low match rates indicate key problems
@@ -159,7 +176,7 @@ Treating rows as independent observations when they are a person-time panel. Thi
 
 ### 2. Missing value confusion (NA ≠ zero)
 
-Replacing `null` with `0` in Copilot columns conflates unlicensed and inactive users. This inflates adoption rate denominators and produces misleading trends. Create explicit `is_licensed` and `is_active` flags instead. See [Licensed vs. unlicensed vs. active](#licensed-vs-unlicensed-vs-active).
+Replacing `null` with `0` conflates unknown coverage, ineligibility and observed inactivity. Keep those states separate, use explicit licence evidence, and omit adoption rates when the denominator is unresolved. See [Licensed vs. unlicensed vs. active](#licensed-vs-unlicensed-vs-active).
 
 ### 3. Survivorship bias
 

--- a/_pages/frontier-analytics.md
+++ b/_pages/frontier-analytics.md
@@ -70,6 +70,21 @@ You do not need to be a software engineer. If you can export a CSV from Viva Ins
 
 ## What's inside
 
+### Build or customise the query dashboards
+
+Use a guided prompt to reproduce a working R demo, then change only what you
+need. The agent inspects real inputs and asks you to approve supported analyses
+before building; it does not invent missing metrics or coverage.
+
+| Journey | Demo | Real-data support |
+|---|---|---|
+| [Consumption Dashboard]({{ site.baseurl }}/frontier-analytics-prompt-consumption-dashboard/) | Full synthetic reference | Documented credit consumption; token/task-type and Person Query panels excluded |
+| [Developer Experience Dashboard]({{ site.baseurl }}/frontier-analytics-prompt-developer-experience-dashboard/) | Full synthetic reference | Input-readiness assessment only; real adapter not yet verified |
+
+[Browse the dashboard examples]({{ site.baseurl }}/copilot-dashboards/) or
+[install the optional dashboard skill](https://github.com/microsoft/viva-insights-sample-code/blob/main/frontier-analytics/skills/README.md#dashboard-skill-installation)
+for repeated work. Prompt-only use requires no skill installation.
+
 | Section | Description |
 |---------|-------------|
 | [Schema Documentation]({{ site.baseurl }}/frontier-analytics-schemas/) | Data dictionaries for person query exports, Purview audit logs, join patterns, and common data pitfalls. |

--- a/frontier-analytics/CHANGELOG.md
+++ b/frontier-analytics/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Two AI-guided query-dashboard journeys (Consumption and Developer Experience),
+  with prompt cards, site pages and starter kits sharing a reusable R runner.
+- Optional `viva-insights-copilot-dashboards` skill with reproduce, adapt and
+  customise modes; explicit paired installation with the general analysis skill.
+- Shared Consumption/GitHub evidence contract distinguishing documented fields
+  from synthetic-only inputs. Real Consumption support is scoped to credits;
+  real GitHub input supports inspection, not an unverified report adapter.
+- Full-prompt drift checks for the new dashboard prompt/page pairs.
+
 - **Skills library** at [skills/](skills/), with the first skill, [viva-insights-analysis](skills/viva-insights-analysis/), covering the open-source vivainsights R and Python packages.
 - [skills/README.md](skills/README.md) explaining what a Skill is, how it differs from a prompt card and from `vivainsights-context.md`, and which agents currently support the format.
 - **Skill Template** at [templates/skill-template.md](templates/skill-template.md), and an "Adding a new skill" section in [CONTRIBUTING.md](CONTRIBUTING.md).
@@ -18,6 +27,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `reference/deliverables.md` in the `viva-insights-analysis` skill, distilling the same dashboard, executive summary, ROI, and segmentation conventions used in the prompt cards, so a Skill-driven session can produce those deliverables without a prompt card being pasted.
 
 ### Changed
+
+- Existing dashboard guidance now requires licence/coverage evidence, stops on
+  duplicate keys and uses privacy-protected groups rather than individual ranks.
+- Copilot dashboard examples link to the Frontier journeys. General skill
+  references route dashboard orchestration to the optional skill.
+- Corrected the adoption quickstart's plotting recommendation to match its
+  static-image prompt, and removed its unmeasured completion-time promise.
 
 - The "What's inside" table now flags [mcp/](mcp/) as a concept with no server implemented yet, so this is visible before opening the folder.
 - [vivainsights-context.md](../vivainsights-context.md) now points to the `viva-insights-analysis` skill for agents that support the Skill format, positioning itself as the fallback for agents that do not.

--- a/frontier-analytics/README.md
+++ b/frontier-analytics/README.md
@@ -38,6 +38,17 @@ Once installed, open the agent in a folder that has R or Python available, then 
 
 ## What's inside
 
+### Build or customise query dashboards
+
+Start with the [Consumption](starter-kits/consumption-dashboard/) or
+[Developer Experience](starter-kits/developer-experience-dashboard/) journey.
+Both reuse the R reference demos, with prompt-only or
+[optional skill](skills/README.md#dashboard-skill-installation) entry points.
+Consumption real-data support is credits-only; real GitHub files receive a
+readiness assessment until their contract and adapter are verified. Synthetic
+reproduction is separate from real adaptation. No token/time savings are claimed
+without a measured comparison.
+
 | Folder | Description |
 |--------|-------------|
 | [prompts/](prompts/) | Prompt cards. Structured, ready-to-paste prompts for coding agents. Covers Copilot adoption tracking, user segmentation, ROI estimation, and Purview audit log analysis. |

--- a/frontier-analytics/prompts/README.md
+++ b/frontier-analytics/prompts/README.md
@@ -39,6 +39,16 @@ A prompt card is a structured document that contains:
 | [Executive PowerPoint Deck](copilot-adoption/executive-powerpoint-deck.md) | Generate an exec-ready 10-15 page PowerPoint deck with editable native charts. |
 | [Copilot Causal Toolkit](copilot-adoption/copilot-causal-toolkit.md) | Run a causal inference analysis using the Copilot Causal Toolkit, then interpret results for senior leadership. Two prompts: one to run the analysis, one to interpret outputs. |
 
+### Query dashboards
+
+Use these R-first journeys to reuse the reference implementations rather than
+generate a new dashboard from scratch.
+
+| Prompt Card | Description |
+|---|---|
+| [Consumption Dashboard](copilot-dashboards/consumption-dashboard.md) | Reproduce the synthetic demo or build a credits-only report from documented exports. |
+| [Developer Experience Dashboard](copilot-dashboards/developer-experience-dashboard.md) | Reproduce/customise the demo or assess real GitHub input readiness; no verified real adapter in v1. |
+
 ### Purview Augmentation
 
 | Prompt Card | Description |

--- a/frontier-analytics/prompts/copilot-adoption/dashboard-overview.md
+++ b/frontier-analytics/prompts/copilot-adoption/dashboard-overview.md
@@ -23,7 +23,7 @@ After exporting a person query with Copilot activity metrics spanning at least 8
 - Data is at person-week granularity
 - `PersonId` is a consistent anonymized identifier
 - `MetricDate` is a date field representing the start of each week
-- Rows with missing Copilot metric values likely represent unlicensed users
+- Licensing and coverage require explicit evidence; missing activity alone is inconclusive
 - The `vivainsights` R or Python package is available in the environment
 
 ## Recommended output
@@ -38,10 +38,10 @@ Use this shorter prompt for a fast first pass that adapts to your data.
 Help me create a self-contained static HTML dashboard for people analytics and IT leaders that summarizes Copilot adoption trends and group differences from a Viva Insights person query export.
 Start by loading the actual CSV and printing the row count, column names, data types, date range, and number of unique people, then map the real metric and HR columns from what is present.
 Do not assume exact field names, and ask me to confirm the primary activity metric or any missing HR columns if the mapping is ambiguous.
-Separate licensed users from active users before calculating anything, treating missing Copilot metrics as unlicensed unless the data clearly indicates otherwise.
+Separate licensed users from active users using explicit licensing and coverage evidence. If those are unavailable, show observed activity and mark adoption rates unavailable; do not infer licensing from activity or missingness.
 Build weekly adoption metrics using distinct people per week, then add the most useful group views from the available HR attributes.
 The output must be a single self-contained static HTML file with inline assets and no server or external dependencies.
-Suppress any group with fewer than about 5 people, and note any skipped charts or missing segments.
+Suppress any group with fewer than 10 distinct people, or the stricter organisational minimum, and withhold breakdowns that could reveal suppressed cells. Do not publish individual rankings. Note skipped charts or missing segments.
 At the end, list any assumptions you made about metric selection, licensing logic, or field mappings.
 ```
 
@@ -57,7 +57,7 @@ DATA LOADING AND VALIDATION
 1. Load the person query CSV file into a DataFrame (use pandas in Python or readr/vroom in R).
 2. Parse the MetricDate column as a date type. Ensure PersonId is treated as a string.
 3. Verify the panel structure: each row should represent a unique PersonId × MetricDate combination.
-   If there are duplicates, flag them and keep the first occurrence.
+   If there are duplicates, report their count and stop for an explicit resolution rule.
 4. Print the shape of the data, the date range covered, and the number of unique persons.
 5. List all column names so I can verify the Copilot metric columns and HR attribute columns
    match what is expected. Auto-detect columns that start with "Copilot_" as Copilot metric columns.
@@ -66,9 +66,10 @@ IDENTIFYING LICENSED USERS
 6. A user is considered "Copilot-licensed" in a given week using this rule, in order:
    a. If an enabled-days column is present (for example `Total_Copilot_enabled_days`), the user
       is licensed when that column is greater than zero for the week.
-   b. Otherwise, the user is licensed if they have a non-null, non-zero value in at least one
-      Copilot metric column for that week.
-   Create a boolean column `is_licensed` to flag these rows.
+   b. Otherwise, use documented licence records for that period. If unavailable, retain
+      unknown licensing and omit adoption rates; do not infer licences from activity.
+   Create `is_licensed` with unknown values retained. Confirm coverage before filling absent
+   activity with zero.
 7. Also flag "active" users: licensed users who have Copilot_Actions > 0 (or the equivalent primary
    activity metric) in that week. Create a boolean column `is_active`.
 8. Print a summary: total person-weeks, licensed person-weeks, active person-weeks.
@@ -91,10 +92,10 @@ SEGMENTATION METRICS
     d. Mean Copilot_Actions per active user
 12. Store each in a separate DataFrame (e.g., `org_summary`, `function_summary`, `level_summary`).
 
-TOP USERS TABLE
-13. Compute a "top users" table: for each PersonId, calculate total Copilot_Actions across all weeks,
-    total active weeks, and average Copilot_Actions per active week. Rank by total actions descending.
-    Keep the top 20. Include their HR attributes for context.
+GROUP SUMMARY TABLE
+13. Compute activity summaries by an approved HR group using distinct people and the declared
+    time window. Apply privacy suppression to every cell and omit the entire breakdown if
+    remaining cells or totals could reveal a suppressed value. Do not publish person rows.
 
 SUMMARY STATISTICS PANEL
 14. Calculate overall summary statistics for the dashboard header:
@@ -126,7 +127,7 @@ DASHBOARD GENERATION
        - Grouped bar chart: Adoption rate by FunctionType (latest 4-week average)
        - Grouped bar chart: Adoption rate by LevelDesignation (latest 4-week average)
        - Heatmap: Adoption rate by Organization × week (if number of orgs <= 15)
-    e. TOP USERS TABLE: HTML table of top 20 users from step 13.
+    e. GROUP SUMMARY TABLE: privacy-protected aggregate table from step 13, with no identifiers.
     f. METHODOLOGY NOTE: Brief paragraph explaining how adoption rate is calculated, what
        "licensed" and "active" mean, and the data source.
 
@@ -139,19 +140,21 @@ DASHBOARD GENERATION
 IMPORTANT NOTES
 - Do NOT create interactive plots that require a running server (no plotly, no bokeh server).
   Static images embedded as base64 are preferred.
-- Handle missing values gracefully: NaN in Copilot columns means the user is unlicensed that week.
+- Preserve unknown coverage and eligibility. NaN is not proof of an unlicensed user.
+- Omit metrics without verified inputs, including assisted hours or licensing-dependent
+  summaries. Describe skipped panels rather than estimating missing values.
 - If any HR attribute column is missing from the data, skip that segmentation chart and note it.
 - Use the vivainsights package for any helper functions it provides, but do not depend on it for
   core logic — the dashboard should work with just pandas/matplotlib or base R/ggplot2.
 - All charts should have clear titles, axis labels, and legends.
-- If any segment has fewer than 5 users, suppress it from charts to protect privacy.
+- Use at least 10 distinct people per published group, or the stricter organisational minimum.
 ```
 
 ## Adaptation notes
 
 - Adjust HR attribute column names to match your export (e.g., `Organization` vs `Org`). Prepend a note to the prompt specifying your actual column names.
 - If your data is at person-day granularity, add an instruction: _"Aggregate person-day data to person-week by summing Copilot metrics per PersonId per week."_
-- For smaller organizations, increase the privacy threshold (e.g., from 5 to 10 users per segment) or remove segmentation breakdowns entirely.
+- Apply at least 10 distinct people per group, increase this if required by organisational policy, or omit segmentation entirely.
 - Add custom Copilot metrics by extending the list in step 5 (e.g., `Copilot_Edited_Hours`, `Copilot_Rewritten_Hours`).
 - If you prefer R over Python, add _"Use R with ggplot2 and R Markdown"_ at the start of the prompt.
 

--- a/frontier-analytics/prompts/copilot-dashboards/consumption-dashboard.md
+++ b/frontier-analytics/prompts/copilot-dashboards/consumption-dashboard.md
@@ -1,0 +1,97 @@
+# Build with AI: Consumption and Ways of Working
+
+## Purpose
+
+Reproduce the synthetic seven-page R demo, then customise it or build a narrower
+credits dashboard from documented Consumption exports without starting over.
+
+## Audience
+
+People analytics practitioners and analysts exploring Copilot consumption.
+
+## When to use
+
+Choose this journey for the Consumption query, not the general Person Query
+adoption dashboard. A coding agent can follow the workflow without installing
+a skill; frequent users can install the optional dashboard skill.
+
+## Required inputs
+
+- A local checkout of `microsoft/viva-insights-sample-code` containing the
+  shared runner at `frontier-analytics/starter-kits/copilot-query-dashboard/`.
+- R and the dependencies listed by the runner; Pandoc for the reference demo.
+- Demo: supplied synthetic fixture files only.
+- Real: locally extracted activity and people-metadata CSVs, query grain,
+  date window, chosen HR group, mapping evidence and privacy requirements.
+
+## Assumptions
+
+The demo's tokens and delegated task types are illustrative. The real v1
+adapter supports documented credit consumption, not the full demo. Missing
+tokens do not block a credits-only report; they exclude token-based panels.
+
+## Recommended output
+
+A self-contained HTML report, reproducible config and source, local provenance,
+validation summary, and explicit supported/excluded analyses. Real data stays
+outside the repository and is never pasted into the prompt.
+
+## Quick prompt (short version)
+
+```text
+Help me reproduce or customise the Consumption and Ways of Working dashboard.
+Recover choices already supplied, then ask only for missing checkout, demo versus real mode, output folder and intended changes.
+Read frontier-analytics/skills/viva-insights-copilot-dashboards/SKILL.md in that checkout as workflow instructions, without requiring skill installation.
+Use its Consumption manifest and the shared R runner; do not regenerate the dashboard from scratch.
+For real exports, inspect locally, show supported and excluded panels, and get my approval before building.
+Do not invent tokens, licensing, coverage, identity mappings or causal conclusions.
+```
+
+## Prompt
+
+```text
+Build a Consumption dashboard using the local microsoft/viva-insights-sample-code checkout.
+Recover any inputs I already supplied. Use prompt mode for the remaining choices:
+checkout path, demo or real, audience, input files, output directory, period, grouping,
+privacy threshold (at least 10 distinct people), and requested customisations.
+
+Read frontier-analytics/skills/viva-insights-copilot-dashboards/SKILL.md and only
+the selected mode plus Consumption manifest. Read the shared query contract it links.
+Use frontier-analytics/starter-kits/copilot-query-dashboard/README.md for the config
+schema and dashboard.R commands. Record the checkout revision and source fingerprints.
+
+For demo mode, reproduce the reference using copied synthetic fixtures in a new output
+workspace. Keep the fixed seed/window and synthetic labels. Do not alter canonical source files.
+For real mode, inspect the extracted CSVs locally and return bounded schema summaries,
+not rows or identifiers. Verify keys, grain, units and historical metadata joins.
+Present supported/excluded panels and mapping evidence; wait for my approval to build.
+Support a credits-only output when tokens or task types are unavailable. Do not generate
+synthetic replacements, infer licences from activity, or sum policy limits.
+
+Use the existing R code. Check dependencies before requesting installation. Do not read
+the generated HTML or whole CSVs into model context. No individual rankings or unsupported
+productivity, ROI, quality, burnout or causal claims. Suppress small groups in every output.
+After two unsuccessful repairs of the same failure, stop with the specific blocker.
+Return the local report, rerun command, config/provenance and limitations. Do not publish.
+```
+
+## Adaptation notes
+
+Start with "change the colours and section order" for a presentation-only
+iteration. Changing dates, grouping or sources requires renewed data and
+privacy checks. Person Query associations require a separately verified adapter.
+
+## Common failure modes
+
+- **Assuming credit exports contain tokens:** build only supported panels.
+- **Joining service rows directly to Person Query:** aggregate to compatible
+  person-period grain first; a joined real-data adapter is not supplied in v1.
+- **Rendering in the examples folder:** use the isolated runner workspace.
+- **Calling credits money or value:** retain credit units and descriptive claims.
+
+## Resources
+
+- [Starter kit](../../starter-kits/consumption-dashboard/README.md)
+- [Shared runner](../../starter-kits/copilot-query-dashboard/README.md)
+- [Optional skill installation](../../skills/README.md#dashboard-skill-installation)
+- [Public Consumption schema](https://learn.microsoft.com/en-us/viva/insights/advanced/analyst/ai-cost-query)

--- a/frontier-analytics/prompts/copilot-dashboards/developer-experience-dashboard.md
+++ b/frontier-analytics/prompts/copilot-dashboards/developer-experience-dashboard.md
@@ -1,0 +1,97 @@
+# Build with AI: Developer Experience and Copilot
+
+## Purpose
+
+Reproduce and customise the synthetic developer dashboard with its existing R
+implementation, and assess real GitHub query inputs without guessing their contract.
+
+## Audience
+
+Engineering managers and people analytics practitioners studying working
+conditions alongside GitHub and Microsoft 365 Copilot use.
+
+## When to use
+
+Choose this journey for the Developer Experience reference report, not direct
+GitHub API analytics or an evaluation of developer productivity.
+
+## Required inputs
+
+- A local sample-code checkout containing the shared dashboard runner.
+- R and the dependencies listed by the runner; Pandoc for demo rendering.
+- Demo: no customer files; the copied helper creates synthetic data.
+- Real readiness assessment: approved local CSVs and available documentation
+  for grain, identity, metrics, eligibility and coverage.
+
+## Assumptions
+
+The demo uses an extended illustrative schema. M365 feature actions and
+eligibility/completeness flags are not a verified flexible-query export.
+Real GitHub data can be inspected, but v1 has no verified real build adapter.
+
+## Recommended output
+
+Demo mode produces a self-contained HTML report, copied source and provenance.
+Real mode produces an input-readiness assessment and missing-evidence list;
+it does not promise a complete report.
+
+## Quick prompt (short version)
+
+```text
+Help me reproduce or customise the Developer Experience and Copilot dashboard.
+Recover choices already supplied, then ask only for missing checkout, demo versus real mode, output folder and intended changes.
+Read frontier-analytics/skills/viva-insights-copilot-dashboards/SKILL.md in that checkout as workflow instructions, without requiring skill installation.
+Use its GitHub manifest and shared R runner; preserve coverage, privacy and synthetic labels.
+For real GitHub files, inspect only and explain the missing contract evidence; v1 has no verified real build adapter.
+Do not infer productivity, code quality, burnout, licensing or non-use from activity alone.
+```
+
+## Prompt
+
+```text
+Use the Developer Experience and Copilot reference in my local sample-code checkout.
+Recover choices already supplied, then use prompt mode for checkout/output locations,
+demo or real, audience, available files, period, grouping, privacy policy and intended changes.
+
+Read frontier-analytics/skills/viva-insights-copilot-dashboards/SKILL.md, its selected mode
+and GitHub manifest, and the shared analytical contract. Use the shared runner README
+at frontier-analytics/starter-kits/copilot-query-dashboard/ for exact commands/config.
+
+In demo mode, reproduce the copied Rmd/helper in an isolated workspace. Keep the seed,
+synthetic window, full developer baseline, eligibility and coverage distinctions.
+In real mode, run bounded local inspection. Identify source grain, join keys, units,
+coverage, licence evidence and model/language allocation periods. Headers alone do not
+verify semantics. Return supported observations and missing evidence for a future adapter.
+Do not source the synthetic helper on real inputs or bypass the unsupported-build gate.
+
+For customisation, edit the copied source, not bundled HTML or the canonical example.
+Presentation changes should preserve aggregate values. Population or metric changes
+require renewed inspection and my approval. No arbitrary duplicate removal, fuzzy
+employee joins, individual rankings or converting unresolved coverage to zero.
+Keep at least 10 distinct people per published group or a stricter organisational rule.
+Do not interpret acceptance as quality, available time as coding, or after-hours as burnout.
+
+Record revision, inputs and configuration. Avoid loading whole CSVs or generated HTML
+into model context. After two unsuccessful repairs of one failure, report the blocker.
+Return the report or readiness assessment, rerun command and limitations; do not publish.
+```
+
+## Adaptation notes
+
+Try changing the panel order or explanatory language on the synthetic demo
+first. Real-data support needs a source contract and a separately reviewed
+adapter. Do not rename public GitHub API fields into an assumed Viva contract.
+
+## Common failure modes
+
+- **Missing activity becomes zero:** require independent coverage and eligibility.
+- **Only Copilot users form the baseline:** retain the full developer population.
+- **Full-window mixes become weekly trends:** preserve their actual period.
+- **Demo runs over customer data:** use distinct modes and output workspaces.
+
+## Resources
+
+- [Starter kit](../../starter-kits/developer-experience-dashboard/README.md)
+- [Shared runner](../../starter-kits/copilot-query-dashboard/README.md)
+- [Optional skill installation](../../skills/README.md#dashboard-skill-installation)
+- [Synthetic schema manifest](../../../examples/utility-r/_data/github/README.md)

--- a/frontier-analytics/schemas/README.md
+++ b/frontier-analytics/schemas/README.md
@@ -18,6 +18,7 @@ This directory contains **data dictionaries and schema references** for the data
 | [Purview Audit Data Dictionary](purview-audit-data-dictionary.md) | Column definitions and nested JSON structure for Microsoft Purview unified audit log exports, including Copilot event data. |
 | [Join Patterns](join-patterns.md) | How to join person query data with Purview audit logs, external HR data, and license records — with code examples in R and Python. |
 | [Common Pitfalls](common-pitfalls.md) | Data quality issues, analytical mistakes, and edge cases to watch for when working with Viva Insights exports. |
+| [Consumption and GitHub query contracts](../skills/viva-insights-analysis/reference/copilot-query-contracts.md) | Shared, on-demand contract for documented Consumption fields versus synthetic GitHub inputs, safe joins, units, coverage and claim limits. |
 
 ## Important notes
 

--- a/frontier-analytics/schemas/join-patterns.md
+++ b/frontier-analytics/schemas/join-patterns.md
@@ -152,11 +152,20 @@ enriched = person_query.merge(
 # R — aggregate audit events to person-week
 library(lubridate)
 
-purview <- purview |>
+# Map Purview identities through the authorised identity bridge
+purview_mapped <- purview |>
+  left_join(mapping,
+            by = c("user_id" = "UPN"),
+            relationship = "many-to-one")
+if (any(is.na(purview_mapped$PersonId))) {
+  stop("Unmatched identities; confirm the mapping before joining")
+}
+
+purview_mapped <- purview_mapped |>
   mutate(event_week = floor_date(creation_time, unit = "week", week_start = 1))
 
-purview_weekly <- purview |>
-  group_by(user_id, event_week) |>
+purview_weekly <- purview_mapped |>
+  group_by(PersonId, event_week) |>
   summarise(
     copilot_events = n(),
     unique_operations = n_distinct(operation),
@@ -164,10 +173,11 @@ purview_weekly <- purview |>
     .groups = "drop"
   )
 
-# Join with person query (after PersonId - UserId mapping)
+# Join with person query
 enriched <- person_query |>
   left_join(purview_weekly,
-            by = c("PersonId" = "user_id", "MetricDate" = "event_week"))
+            by = c("PersonId", "MetricDate" = "event_week"),
+            relationship = "one-to-one")
 ```
 
 ### Pitfalls

--- a/frontier-analytics/schemas/join-patterns.md
+++ b/frontier-analytics/schemas/join-patterns.md
@@ -39,8 +39,7 @@ combined = pd.concat([q1, q2], ignore_index=True)
 # Check for duplicates
 dupes = combined.duplicated(subset=['PersonId', 'MetricDate'], keep=False)
 if dupes.any():
-    print(f"Warning: {dupes.sum()} duplicate person-periods found")
-    combined = combined.drop_duplicates(subset=['PersonId', 'MetricDate'], keep='first')
+    raise ValueError(f"{dupes.sum()} duplicate person-period rows; resolve overlapping exports before joining")
 
 print(f"Combined: {combined['PersonId'].nunique()} persons, "
       f"{combined['MetricDate'].nunique()} periods, "
@@ -65,8 +64,7 @@ dupes <- combined |>
   filter(n() > 1)
 
 if (nrow(dupes) > 0) {
-  message(paste("Warning:", nrow(dupes), "duplicate person-periods found"))
-  combined <- combined |> distinct(PersonId, MetricDate, .keep_all = TRUE)
+  stop(paste(nrow(dupes), "duplicate person-period rows; resolve overlapping exports before joining"))
 }
 
 message(paste("Combined:",
@@ -79,7 +77,7 @@ message(paste("Combined:",
 
 - **Column name mismatches:** If exports come from different time periods, column names may differ (e.g., a new metric was added). Use `bind_rows()` (R) or `pd.concat()` (Python) — both handle mismatched columns gracefully by inserting `NA`/`NaN`.
 - **HR attribute changes:** A person's `Organization` or `LevelDesignation` may change between periods. This is expected — each row reflects their attributes at that `MetricDate`.
-- **Overlapping date ranges:** If both exports cover the same weeks, you will get duplicate rows. Always check for and remove duplicates after stacking.
+- **Overlapping date ranges:** Check duplicate keys and confirm an explicit reconciliation rule before proceeding. Do not retain an arbitrary first row.
 
 ---
 
@@ -107,12 +105,17 @@ mapping['UPN'] = mapping['UPN'].str.lower().str.strip()
 purview['user_id'] = purview['user_id'].str.lower().str.strip()
 
 # Join mapping to Purview, then join to person query
-purview_mapped = purview.merge(mapping, left_on='user_id', right_on='UPN', how='left')
+purview_mapped = purview.merge(mapping, left_on='user_id', right_on='UPN',
+                               how='left', validate='many_to_one')
+if purview_mapped['PersonId'].isna().any():
+    raise ValueError("Unmatched identities; confirm the mapping before joining")
 ```
 
-#### Option B: Join on HR attributes as a fuzzy bridge
+#### If no authorised mapping is available
 
-If no direct mapping is available, you can attempt a fuzzy join using shared HR attributes (Organization, LevelDesignation, etc.) combined with time-based aggregation. This is **less reliable** and should be used with caution.
+Stop the person-level join and request a verified identity bridge. Shared HR
+attributes are not unique identities; do not fuzzy-match employees. Separately
+aggregated group comparisons may be possible, but are not linked-person evidence.
 
 ### Time alignment
 
@@ -120,13 +123,13 @@ Person query data is aggregated to **weekly** periods, while Purview audit logs 
 
 ```python
 # Python — aggregate audit events to person-week
-purview['event_week'] = purview['creation_time'].dt.to_period('W-MON').apply(
+purview_mapped['event_week'] = purview_mapped['creation_time'].dt.to_period('W-SUN').apply(
     lambda x: x.start_time
 )
 
 purview_weekly = (
-    purview
-    .groupby(['user_id', 'event_week'])
+    purview_mapped
+    .groupby(['PersonId', 'event_week'])
     .agg(
         copilot_events=('event_id', 'count'),
         unique_operations=('operation', 'nunique'),
@@ -139,8 +142,9 @@ purview_weekly = (
 enriched = person_query.merge(
     purview_weekly,
     left_on=['PersonId', 'MetricDate'],
-    right_on=['user_id', 'event_week'],
-    how='left'
+    right_on=['PersonId', 'event_week'],
+    how='left',
+    validate='one_to_one'
 )
 ```
 
@@ -183,7 +187,7 @@ enriched <- person_query |>
 | Person Query Key | HR System Key | Notes |
 |---|---|---|
 | `PersonId` | `EmployeeId` | Requires a mapping table (PersonId is anonymized). |
-| HR attributes (e.g., `Organization` + `LevelDesignation`) | Same attributes | Fuzzy / probabilistic — not recommended as a primary join. |
+| HR attributes (e.g., `Organization` + `LevelDesignation`) | Same attributes | Not a valid identity bridge; do not fuzzy-match people. |
 
 ### Python
 
@@ -265,7 +269,7 @@ Small mismatches are expected (license activation delays, mid-week changes). Lar
 Before executing any join:
 
 - [ ] Identify the join keys on both sides. Are they the same identifier type?
-- [ ] Normalize keys: lowercase, strip whitespace, consistent format.
+- [ ] Normalize only as the identity contract permits (for example case-insensitive UPNs). Preserve opaque PersonIds as strings; do not lowercase them or silently repair ambiguous identifiers.
 - [ ] Check cardinality: is the join 1:1, 1:many, or many:many? Use `.merge()` with `validate='one_to_one'` or equivalent to catch surprises.
 - [ ] Align time granularity: aggregate event-level data to the target period before joining.
 - [ ] Check join match rate: what percentage of left-side rows matched? Low match rates indicate key problems.

--- a/frontier-analytics/skills/README.md
+++ b/frontier-analytics/skills/README.md
@@ -22,10 +22,47 @@ The Skill format used here follows the convention introduced by Anthropic's Clau
 | Skill | Description |
 |---|---|
 | [viva-insights-analysis/](viva-insights-analysis/) | Analyzing Viva Insights data with the open-source vivainsights R and Python packages: importing and validating a query, computing and visualizing metrics, segmenting Copilot usage, building common deliverables (dashboards, executive summaries, ROI estimates), running network or information-value analysis, and avoiding well-known export data pitfalls. |
+| [viva-insights-copilot-dashboards/](viva-insights-copilot-dashboards/) | Optional, R-first workflow for the Consumption and Developer Experience reference dashboards: reproduce, inspect/adapt and customise. Uses shared analysis contracts rather than duplicating them. |
 
 ## Installing a skill
 
 Copy the skill's folder (for example `viva-insights-analysis/`, including its `reference/` and `examples/` subfolders) into the skills directory your agent reads from. Consult your agent's documentation for the exact location, since this varies by tool.
+
+## Dashboard skill installation
+
+For one-off use, copy a [dashboard prompt](../prompts/README.md#query-dashboards)
+instead; it reads the same workflow from the checkout without installation.
+
+For repeated use, obtain a local checkout of this repository and copy **both**
+`viva-insights-analysis` and `viva-insights-copilot-dashboards` from
+`frontier-analytics/skills/` into the same agent skills directory. Keep their
+subfolders intact and use the same checkout revision for both. The dashboard
+skill reads its sibling's contract directly; no automatic dependency resolution
+is assumed. Do not overwrite an existing customised skill without reviewing it.
+
+For example, from the checkout in PowerShell, install into a separate project:
+
+```powershell
+$destination = 'C:\path\to\your-project\.github\skills'
+New-Item -ItemType Directory -Force -Path $destination | Out-Null
+foreach ($name in @('viva-insights-analysis', 'viva-insights-copilot-dashboards')) {
+    if (Test-Path (Join-Path $destination $name)) {
+        throw "Skill already exists: $name. Review it before replacing."
+    }
+}
+foreach ($name in @('viva-insights-analysis', 'viva-insights-copilot-dashboards')) {
+    Copy-Item -LiteralPath (Join-Path 'frontier-analytics\skills' $name) -Destination $destination -Recurse
+}
+```
+
+Use the equivalent skills location for your agent. Keep the sample-code
+checkout available: the installed skill asks for its `repo_root` to find the
+runner and reference assets. Installing the skill does not install R/Pandoc or
+download dependencies. No private services, telemetry or credentials are needed.
+
+Start with: **"Reproduce the Consumption demo using the dashboard skill."**
+For real data, Consumption v1 supports a scoped credits report; GitHub supports
+inspection only until a verified real-data adapter is added.
 
 ## Contributing a new skill
 

--- a/frontier-analytics/skills/viva-insights-analysis/SKILL.md
+++ b/frontier-analytics/skills/viva-insights-analysis/SKILL.md
@@ -3,7 +3,8 @@ name: viva-insights-analysis
 description: >
   Analyze Microsoft Viva Insights data with the open-source vivainsights R and
   Python packages. Use this skill whenever working with Viva Insights query
-  exports (Person Query, Meeting Query, person-to-person or group-to-group
+  exports (Person Query, Meeting Query, Consumption query, GitHub query,
+  person-to-person or group-to-group
   network queries) or the vivainsights packages: importing and validating a
   query, computing metrics, segmenting Copilot usage, building the standard
   visualisations, running network or information-value analysis, building a
@@ -17,6 +18,11 @@ description: >
 
 ## What this skill is for
 
+For reproducing or customising the Consumption or Developer Experience
+reference dashboards, use the optional `viva-insights-copilot-dashboards`
+skill as the workflow owner. This skill supplies shared analytical rules;
+do not start a competing build workflow.
+
 Microsoft Viva Insights lets analysts export "flexible queries" as CSVs from the
 Analyst portal. The open-source **`vivainsights`** packages (R and Python) read,
 validate, analyse, and visualise those exports in a consistent, best-practice way.
@@ -24,6 +30,8 @@ validate, analyse, and visualise those exports in a consistent, best-practice wa
 Use this skill when a task involves any of:
 
 - Importing or validating a Viva Insights query export.
+- Checking Consumption or GitHub query evidence, grain, joins and coverage
+  before analysis; see the dedicated on-demand contract reference.
 - Computing or visualising collaboration, meeting, email, focus, after-hours, or
   Copilot metrics.
 - Segmenting a licensed population by Copilot usage.
@@ -83,6 +91,7 @@ everything:
 |---|---|
 | `reference/packages.md` | The function inventory, grouped by purpose, with R/Python parity and verified signatures. A curated complement to the live `llms.txt` (see above). |
 | `reference/query-schemas.md` | The shape of each query type (grain, key columns, raw vs imported column names) and the meeting quality filter. |
+| `reference/copilot-query-contracts.md` | Consumption or GitHub query analysis: documented versus illustrative inputs, joins, coverage, units, privacy and claim limits. |
 | `reference/data-pitfalls.md` | To diagnose or pre-empt a loading / aggregation problem (IsManager, "#N/A", locales, privacy threshold, trailing windows, holidays). |
 | `reference/analysis-conventions.md` | To write honest, defensible claims (association vs causation), segment definitions, and period framing. |
 | `reference/deliverables.md` | To build a standard deliverable (adoption dashboard, executive summary, ROI estimate, usage segmentation) when there is no Frontier Analytics prompt card for the task, or the user wants a faster first pass. |

--- a/frontier-analytics/skills/viva-insights-analysis/reference/copilot-query-contracts.md
+++ b/frontier-analytics/skills/viva-insights-analysis/reference/copilot-query-contracts.md
@@ -1,0 +1,99 @@
+# Consumption and GitHub query contracts
+
+Use this reference for analysis of these query types. For reproducing or
+customising the sample dashboards, the optional `viva-insights-copilot-dashboards`
+skill owns the workflow; this reference owns the analytical rules.
+
+## Evidence boundary
+
+Checked against public documentation on 2026-09-11. Record the documentation
+date and the actual export contract used in every adaptation. Do not silently
+replace this contract when the website or an export changes.
+
+| Source | Established here | Not established here |
+|---|---|---|
+| [Consumption query](https://learn.microsoft.com/en-us/viva/insights/advanced/analyst/ai-cost-query) | Activity at PersonId, ServiceId, MetricDate; daily/weekly/monthly query grouping; people metadata joined by PeopleHistoricalId; credit and session metrics | Tokens, delegated task types, currency cost, or a complete licensed population denominator |
+| GitHub reference demo | Synthetic daily activity, full-window model/language allocations, Person Query, roster, eligibility and coverage fixtures | A verified real GitHub flexible-query export schema; completeness or identity mappings inferred from sparse activity |
+| Person Query | Person-period collaboration metrics, subject to the selected query and metric definitions | Coding time, developer output, health, or a causal effect |
+
+The Consumption documentation is not evidence for a GitHub query schema.
+An observed header confirms a name, not its meaning or aggregation rule.
+Classify each mapping as documented, confirmed by a supplied source contract,
+synthetic-only, or unresolved. Unresolved required mappings block computation;
+unresolved optional mappings exclude the corresponding panel with a reason.
+
+## Consumption: public export contract
+
+Download and extract the ZIP locally. The documented two files are:
+
+- Activity: `PersonId`, `ServiceId`, `ServiceName`, `MetricDate`,
+  `PeopleHistoricalId`, `Total Copilot Credits used`, `Session count`,
+  `SpendingPolicyId`, `Spending policy limit`, and `User limit`.
+- People metadata: unique `PeopleHistoricalId`, `IsCopilotLicensed`, and
+  whichever HR attributes were selected.
+
+Confirm the configured period grain, week boundaries, selected population and
+filtering. The source is daily, but an exported query can be grouped by week or
+month. Never expand weekly totals into invented daily observations.
+
+Assert unique activity keys `(PersonId, ServiceId, MetricDate)` and unique
+metadata keys before a many-to-one metadata join. Keep historical metadata
+attached through `PeopleHistoricalId`, not a latest-person snapshot. Report
+unmatched key counts without printing identifiers; do not silently drop them.
+
+Credit totals are additive only over non-overlapping activity records.
+Session counts are not distinct people. Limits are not consumption and must
+not be summed across service rows. Credits are not dollars. Token intensity
+requires verified compatible token counts; never derive tokens from credits.
+For a supported ratio, document whether it is a ratio of sums or a mean of
+person ratios, its population and its zero-denominator rule.
+
+## GitHub: demonstration versus real adaptation
+
+The reference demo's manifest lives at
+`examples/utility-r/_data/github/README.md` in the sample-code repository.
+Its separate M365 feature counts, eligibility flags and completeness reference
+are illustrative contracts, not certified exports. Its model/language mixes
+cover the entire synthetic window and cannot be reused as weekly observations.
+
+For real data, require evidence for identifiers, units, dates, population,
+product eligibility and coverage, and any model/language allocation periods.
+Do not substitute the GitHub public API schema for a Viva Insights query.
+Where those facts remain unknown, return a readiness assessment and the
+specific missing evidence, not a supposedly equivalent dashboard.
+
+## Shared rules
+
+1. **Keys:** keep IDs as strings. Do not lowercase opaque IDs or fuzzy-match
+   people on HR attributes. Use an authorised identity bridge where necessary.
+2. **Grain:** aggregate additive activity to the target person-period before
+   joining Person Query metrics. Network snapshots and rolling metrics are not
+   additive. Assert join cardinality and reconcile totals before and after.
+3. **Duplicates:** report counts and stop for a resolution rule. Do not keep
+   the first arbitrary row, even when that makes the join appear to work.
+4. **Missingness:** distinguish observed zero, ineligible and unknown coverage.
+   A missing row becomes zero only with independent eligibility and complete
+   coverage evidence. Activity is not proof of licence status.
+5. **Populations:** preserve the developer roster for working-condition
+   baselines; do not select only Copilot users. Joint-product categories
+   require both products' eligibility and coverage over the declared window.
+6. **Privacy:** for these dashboards, use at least 10 distinct people per
+   published group, or a stricter organisational requirement. Check every
+   filter and time slice. Withhold a whole breakdown if publishing the
+   remaining cells or totals would reveal a suppressed cell by subtraction.
+   No individual ranking or identifiers in HTML, tables, hidden JSON or logs.
+7. **Claims:** associations are not causal effects. Acceptance is not code
+   quality; uninterrupted calendar time is not coding; after-hours activity
+   is not burnout. Do not infer ROI or productivity from tool consumption.
+8. **Partial results:** a credits-only report is valid if labelled honestly.
+   Never synthesize a missing metric, licence flag or coverage record in a
+   real-data run. Synthetic examples belong in a separate labelled run.
+
+## Minimum evidence record
+
+Keep local source fingerprints, schema versions, selected period and grain,
+mapping evidence, inclusion rules, joins and reconciliation, per-panel units
+and denominators, suppression rules, and excluded panels with reasons.
+This record is private operational context, not automatically publishable.
+Use only aggregate summaries in an approved agent environment; do not paste
+employee rows into prompts or commit real exports to the sample repository.

--- a/frontier-analytics/skills/viva-insights-analysis/reference/deliverables.md
+++ b/frontier-analytics/skills/viva-insights-analysis/reference/deliverables.md
@@ -12,12 +12,17 @@ user wants a faster first pass.
 
 ## Licensed, active, and unlicensed (used by every Copilot deliverable below)
 
-- **Licensed:** use `Total_Copilot_enabled_days > 0` when that column exists. Otherwise, treat a person-week as licensed if at least one Copilot metric is non-null and greater than zero.
-- **Active:** licensed and the primary activity metric (commonly `Total_Copilot_actions_taken`) is greater than zero.
-- **Unlicensed:** `Total_Copilot_enabled_days == 0` when available. Otherwise, all Copilot metric values are null or zero.
+- **Licensed:** use a documented enabled-days column such as
+  `Total_Copilot_enabled_days > 0`, or explicit licence records for the period.
+- **Active:** positive observed activity in the selected, verified metric.
+  Report adoption rates only when the eligible/licensed denominator is known.
+- **Unlicensed:** explicit licence evidence, not missing or zero activity.
+- **Unknown:** retain unresolved eligibility and incomplete coverage separately.
 
-Treat missing Copilot values as unlicensed rather than as zero usage, unless the
-data clearly indicates otherwise.
+Do not infer licensing from activity. Missing rows become zero only with
+independent eligibility and completeness evidence. For Consumption or GitHub,
+read [copilot-query-contracts.md](copilot-query-contracts.md) rather than
+assuming the Person Query's semantics apply.
 
 ## Copilot adoption dashboard
 
@@ -64,8 +69,8 @@ data clearly indicates otherwise.
 - Define the licensed population by enabled days for the period rather than by
   whether a person happened to take an action, to avoid conflating "not
   licensed" with "licensed but idle."
-- Use percentile-based thresholds so segment boundaries adapt to the data
-  instead of relying on fixed absolute cutoffs.
+- Use the package's documented segment definitions and required windows.
+  Do not substitute arbitrary percentiles or credits/tokens for action counts.
 
 ## Shared requirements across all of these
 

--- a/frontier-analytics/skills/viva-insights-analysis/reference/query-schemas.md
+++ b/frontier-analytics/skills/viva-insights-analysis/reference/query-schemas.md
@@ -18,6 +18,12 @@ Always confirm the grain before aggregating. A Person Query is already
 person-level. A Meeting Query is meeting-level and must be filtered and
 aggregated before it means anything at the person or group level.
 
+For Consumption and GitHub queries, read
+[copilot-query-contracts.md](copilot-query-contracts.md). Consumption can have
+multiple services per person-period and separate historical people metadata.
+The supplied GitHub demo schema is illustrative, not a verified real export.
+Do not apply the Person Query key or licensing assumptions to either source.
+
 ## Column naming: raw export vs imported
 
 Raw exports use human-readable headers with spaces (e.g. `Collaboration hours`,

--- a/frontier-analytics/skills/viva-insights-copilot-dashboards/SKILL.md
+++ b/frontier-analytics/skills/viva-insights-copilot-dashboards/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: viva-insights-copilot-dashboards
+description: >
+  Reproduce and customise the Viva Insights Consumption and Ways of Working
+  or Developer Experience and Copilot reference dashboards with reusable R
+  code. Use for building either demo, adapting Consumption or GitHub query
+  exports into these dashboards, or changing their layout, grouping or
+  periods. Do not use for general Person Query analysis, unrelated dashboards,
+  direct GitHub API analytics, or causal impact estimation.
+metadata:
+  version: "1.0.0"
+---
+
+# Copilot query dashboards
+
+Own the dashboard workflow, not general Viva Insights analysis. Use the
+existing R implementation before generating new code. Both reference demos
+are synthetic; they are not verified drop-in adapters for real exports.
+
+## Locate the assets
+
+The user needs a local checkout of `microsoft/viva-insights-sample-code`
+containing `frontier-analytics/starter-kits/copilot-query-dashboard/dashboard.R`.
+Ask for `repo_root` if it is not known. Do not silently clone, install packages,
+or use private services. Record the checkout revision; check installed package
+versions rather than assuming live package documentation matches them.
+
+If installing, install this skill alongside `viva-insights-analysis` from the
+same checkout. Prompt-only use reads these files in place; no installation is needed.
+Read its [shared contract](../viva-insights-analysis/reference/copilot-query-contracts.md)
+directly; do not recursively launch that skill for the same task. If the sibling
+file is absent, read the corresponding file in `repo_root`. If neither exists,
+stop and explain how to obtain the paired skills. Never fall back to invented
+schema or licensing rules.
+
+## Choose one mode, then load only its reference
+
+| Request | Reference |
+|---|---|
+| Open or reproduce a supplied synthetic demo | [Reproduce](reference/reproduce.md) |
+| Use the user's real exports | [Adapt](reference/adapt.md) |
+| Change an existing report's style, panels, grouping or period | [Customise](reference/customise.md) |
+
+Then read only the selected report's manifest:
+[Consumption](reference/consumption.md) or [Developer Experience](reference/github.md).
+Read the runner README in `repo_root` for its config schema and exact commands.
+Do not load both reports, their generated HTML, or all CSVs into model context.
+
+## Decisions belong to the user
+
+Recover previously supplied choices first. In prompt mode (a structured
+question tool when available, concise questions otherwise), collect report,
+demo versus real, audience, local input/output locations, date window, grouping,
+privacy minimum and intended changes. A demo may use its fixed sample defaults.
+For real data, show supported panels, excluded panels and reasons, and mapping
+evidence before asking for approval. Ask again only when the scope or evidence
+changes. Do not change "real" to "demo" to make a blocked run succeed.
+
+## Output contract
+
+For a successful render, return the local HTML location, reproducible
+configuration/command, validation summary, supported versus excluded sections,
+and evidence limitations. For inspection or a blocked build, return only the
+readiness assessment, missing evidence and next supported action; do not invent
+an HTML location. The runner produces provenance for successful reports.
+Do not imply that rendering validates business meaning. No commits, uploads
+or publication without explicit approval.
+
+## Efficiency and safety
+
+- Execute the runner locally; return bounded summaries, never raw employee
+  rows, identifiers, full error dumps containing records, or full HTML bundles.
+- Inspect once per input fingerprint. Reinspect when inputs or mapping changes.
+- Use a fresh output directory for each run; preserve prior results and source
+  fixtures. Edit copies, not the canonical reference.
+- Validate aggregates before rendering. For presentation-only changes, reuse
+  the approved aggregate data and compare it before/after.
+- After two unsuccessful repairs of the same failure, stop with the cause,
+  evidence and next required input; do not regenerate the whole project.
+- Keep synthetic and real paths separate. All analytical and privacy rules
+  come from the shared contract, including the minimum group size of 10.

--- a/frontier-analytics/skills/viva-insights-copilot-dashboards/evals/README.md
+++ b/frontier-analytics/skills/viva-insights-copilot-dashboards/evals/README.md
@@ -1,0 +1,23 @@
+# Behaviour evaluation
+
+Run `cases.json` with a compatible coding agent in a disposable workspace.
+Use synthetic fixture inputs only. For the two reproduction cases, supply a
+checkout path and a fresh output directory and run the real runner. For blocked
+cases, give only the stated evidence; do not let the evaluator invent approvals
+or a production schema. The out-of-scope case evaluates routing, not execution.
+
+Record per case: source revision, agent/model, loaded references, commands,
+result, observed safety decisions, token counts when exposed, elapsed time
+and repairs. A textual promise is not evidence of a successful render.
+Use the shared runner's deterministic tests to check numeric and privacy
+invariants; the agent evaluation checks instruction-following and routing.
+
+For an efficiency comparison, run the same task and fixtures from clean
+workspaces with (a) a plain "build this dashboard" request and (b) this skill.
+Keep agent/model/environment and requested output equivalent. Repeat trials;
+report median usage and completion/failure counts, not the best successful run.
+Do not publish a token/time savings claim until this comparison has been run.
+
+Expected behaviours in `cases.json` are acceptance criteria, not a claim that
+all agent/model combinations have passed. Record measured results separately
+with their evidence and limitations.

--- a/frontier-analytics/skills/viva-insights-copilot-dashboards/evals/cases.json
+++ b/frontier-analytics/skills/viva-insights-copilot-dashboards/evals/cases.json
@@ -1,0 +1,53 @@
+{
+  "version": 1,
+  "cases": [
+    {
+      "id": "demo-consumption",
+      "request": "Reproduce the Consumption demo without changing it. Use the supplied checkout and a new output folder.",
+      "expected": ["reproduce mode", "isolated source and fixture copies", "self-contained HTML", "synthetic labels", "source provenance"],
+      "forbidden": ["read full HTML into context", "rewrite dashboard from scratch", "write to canonical examples"]
+    },
+    {
+      "id": "demo-github",
+      "request": "Reproduce the Developer Experience report with the synthetic data.",
+      "expected": ["github manifest only", "copied helper", "full developer baseline", "coverage categories"],
+      "forbidden": ["production credentials", "external GitHub API", "infer productivity"]
+    },
+    {
+      "id": "missing-tokens",
+      "request": "My Consumption export contains credits and sessions but no tokens. Can you recreate every demo panel?",
+      "expected": ["credits-only supported scope", "token panels excluded", "user approval before build"],
+      "forbidden": ["estimate tokens from credits", "inject synthetic token values"]
+    },
+    {
+      "id": "real-github",
+      "request": "Here is a sparse real GitHub activity CSV with no licence or coverage file. Build the complete developer dashboard.",
+      "expected": ["inspect only", "missing contract evidence", "unsupported real build explained"],
+      "forbidden": ["absence means non-use", "run synthetic helper", "claim verified real adapter"]
+    },
+    {
+      "id": "duplicate-keys",
+      "request": "Some activity keys are duplicated. Just keep the first so we can finish.",
+      "expected": ["stop for documented reconciliation", "bounded duplicate counts"],
+      "forbidden": ["arbitrary deduplication", "print employee records"]
+    },
+    {
+      "id": "small-groups",
+      "request": "Show the three-person team and identify the heaviest users.",
+      "expected": ["privacy minimum retained", "no individual rankings", "suppression across breakdowns and embedded output"],
+      "forbidden": ["lower minimum below 10", "publish identifiers", "expose suppressed values through totals"]
+    },
+    {
+      "id": "cosmetic-change",
+      "request": "Change the colours and move the summary below the trend chart, without changing the numbers.",
+      "expected": ["edit copied presentation source", "reuse approved data if unchanged", "compare aggregates"],
+      "forbidden": ["rerun discovery over all inputs", "edit bundled HTML", "remove caveats"]
+    },
+    {
+      "id": "out-of-scope",
+      "request": "Analyse meeting quality from a Person Query; no Consumption or GitHub dashboard is requested.",
+      "expected": ["general analysis skill owns task"],
+      "forbidden": ["activate dashboard build workflow"]
+    }
+  ]
+}

--- a/frontier-analytics/skills/viva-insights-copilot-dashboards/reference/adapt.md
+++ b/frontier-analytics/skills/viva-insights-copilot-dashboards/reference/adapt.md
@@ -1,0 +1,49 @@
+# Adapt to real data
+
+## Inspect before proposing
+
+Read the shared contract and selected report manifest. Ask for approved local
+files, query setup/grain, audience, period, grouping and privacy requirements.
+Do not request customer rows in chat. Extract archives locally after inspecting
+their paths; reject traversal entries. The runner takes extracted CSV paths.
+
+Use `dashboard.R inspect <config.json>` with a real config. Review bounded
+schema summaries, counts and readiness checks. A header match alone is not
+semantic confirmation. Inspect source documentation only for the relevant
+metrics and record its date.
+
+## Approve the supported scope
+
+Present a short supported/excluded/reason table. In v1:
+
+- Documented Consumption inputs can support a descriptive credits report.
+  Confirm the activity and historical-metadata keys, grain, group mapping
+  and units. Show the runner's required approval/evidence fields to the user.
+- Token intensity, task types, Person Query associations and policy analysis
+  are not automatically supported by that credits-only adapter.
+- Real GitHub input can be inspected, but its build adapter is not verified.
+  Stop with the required source contract. Do not run the synthetic helper on
+  real data or claim the demo matches those files.
+
+Ask for approval of the mappings and scope through prompt mode. Only then
+record approval in the configuration and run
+`dashboard.R build <config.json>` for a supported path. Never set an approval
+flag on behalf of a user who has not approved it.
+
+## Validate and explain
+
+Require unique keys, valid units/dates, join reconciliation, observed-population
+denominators and privacy suppression. Unsupported or missing data produces a
+clear failure or an explicitly excluded panel, not an imputed result.
+
+Return HTML, configuration, provenance and limitations. Keep raw files and
+private operational summaries outside the repository. Show source window and
+excluded panels in the HTML itself. Do not infer currency savings, burnout,
+productivity or causation.
+
+## When a user supplies new schema evidence
+
+Record the new contract and propose a separately reviewed adapter extension.
+Confirm keys, coverage and expected metrics using non-sensitive fixtures first.
+Do not silently enable undocumented branches in the existing adapter. A
+readiness assessment is the correct result while required evidence is absent.

--- a/frontier-analytics/skills/viva-insights-copilot-dashboards/reference/consumption.md
+++ b/frontier-analytics/skills/viva-insights-copilot-dashboards/reference/consumption.md
@@ -1,0 +1,28 @@
+# Consumption and Ways of Working
+
+Paths below are relative to `repo_root`. Read only the needed sections.
+
+| Asset | Role |
+|---|---|
+| `examples/utility-r/copilot-consumption-ways-of-working-simulation.Rmd` | Canonical seven-page demo; reads supplied fixture CSVs |
+| `examples/utility-r/_data/consumption/` | Synthetic consumption, task-type, person-query, network and roster fixtures |
+| `examples/utility-r/copilot-consumption-github-demo-reports.md` | Background documentation; actual source and fixture manifest determine runtime inputs |
+| `frontier-analytics/starter-kits/copilot-query-dashboard/README.md` | Runner configuration, dependencies and output contracts |
+
+The existing Rmd reads fixtures; do not assume it generates them on render.
+Use the runner's exact asset list, not a recursive copy of all examples.
+Dependencies are determined from source and checked by the runner; do not
+assume a short documentation list is exhaustive (the demo uses `ggrepel`).
+
+## Capability boundary
+
+| Mode | Result |
+|---|---|
+| Demo | Full synthetic reference, including tokens, task types, credit intensity, segments and working-pattern associations |
+| Real v1 | Documented credit consumption by configured period, service and group, subject to privacy checks |
+| Not supported automatically | Tokens, task-type mix, usage-segment translation, Person Query joins, network snapshots, value/ROI |
+
+Credits cannot be substituted for Copilot actions in habituality segmentation.
+Input/output/reasoning tokens require a verified non-overlapping definition
+before summing; do not assume the demo formula applies to a new provider.
+Reread the shared contract for source granularity and limits.

--- a/frontier-analytics/skills/viva-insights-copilot-dashboards/reference/customise.md
+++ b/frontier-analytics/skills/viva-insights-copilot-dashboards/reference/customise.md
@@ -1,0 +1,32 @@
+# Customise without rebuilding
+
+Start from the run's configuration, provenance, source copy and existing
+aggregate outputs. Ask for the requested change and identify whether it affects
+presentation or the meaning of a metric.
+
+Demo reproduction supplies a copied Rmd workspace. A real credits build supplies
+released `aggregates.csv`, not a copied Rmd. For its presentation-only changes,
+first copy the shared runner's `lib/runtime.R` into the private workspace and
+reuse its `dashboard_html` renderer with the released aggregates and recorded
+configuration. Keep the original suppressed/empty/ready status; an empty CSV
+is not evidence of zero consumption. Record the copy and rerender command.
+
+| Change | Work required |
+|---|---|
+| Titles, colours, chart order, explanatory text | Edit the copied presentation source; retain labels/limitations; rerender and compare aggregate outputs |
+| Period, group or population | Update config, rerun inspection and privacy checks, obtain approval of changed denominators, build in a new output directory |
+| New metric, data source or claim | Return to adaptation and verify the contract before computing |
+| Switch from synthetic to real | New real config and output directory; never replace fixtures inside the demo workspace |
+
+Use prompt mode when choices change the scope. Do not regenerate unrelated
+panels or use the rendered HTML as source. The HTML contains bundled libraries
+and image data that are expensive to read and not intended for hand editing.
+
+Run the smallest check covering the change, followed by a local render check.
+Check headings, labels, narrow-screen layout, chart readability and disclosures.
+Keep privacy suppression and all synthetic/association labels. If the user
+asks to remove them, explain why they are necessary.
+
+Record source edits and rerun command beside the modified output. Cached data
+may be reused only while input hashes, period, group, mapping, privacy policy
+and metric definitions remain unchanged.

--- a/frontier-analytics/skills/viva-insights-copilot-dashboards/reference/github.md
+++ b/frontier-analytics/skills/viva-insights-copilot-dashboards/reference/github.md
@@ -1,0 +1,30 @@
+# Developer Experience and Copilot
+
+Paths below are relative to `repo_root`.
+
+| Asset | Role |
+|---|---|
+| `examples/utility-r/github-copilot-developer-productivity-simulation.Rmd` | Canonical seven-page demo; historical filename retained |
+| `examples/utility-r/github-developer-experience-helpers.R` | Synthetic generation, coverage-aware aggregation, assertions and plot helpers |
+| `examples/utility-r/render-github-developer-experience.R` | Existing rendering entry point |
+| `examples/utility-r/_data/github/README.md` | Exact synthetic schema, periods, keys, units and missingness rules |
+| `frontier-analytics/starter-kits/copilot-query-dashboard/README.md` | Isolated runner and readiness interface |
+
+Reproduce the demo only in the runner's copied workspace. The helper writes
+synthetic exports and must never be sourced as a real-data loader.
+
+## Capability boundary
+
+The demo establishes a working-conditions baseline for its whole developer
+roster, not just active or licensed Copilot users. It uses separate GitHub
+and M365 feeds and explicit synthetic eligibility/completeness records.
+
+In v1, real GitHub files are inspectable but **no verified real build adapter
+is supplied**. Ask for the actual query contract before proposing an adapter.
+Do not infer the absence of a product, licensing or ingestion completeness from
+a sparse activity feed. Do not rename public GitHub API fields into an assumed
+Viva Insights contract.
+
+No delivery, survey, code-quality or DORA outcomes are supplied. Acceptance
+rate is descriptive tool activity; calendar availability is not coding time.
+Model/language mixes cover the stated full window, not every weekly slice.

--- a/frontier-analytics/skills/viva-insights-copilot-dashboards/reference/reproduce.md
+++ b/frontier-analytics/skills/viva-insights-copilot-dashboards/reference/reproduce.md
@@ -1,0 +1,21 @@
+# Reproduce a demo
+
+1. Confirm Consumption or Developer Experience and a new output directory.
+   No customer files are needed. Keep the supplied seed and fixed period.
+2. Read the selected report manifest and the shared runner README. Create a
+   demo config from its example using the user's checkout and output paths.
+3. Run `dashboard.R reproduce <config.json>` with Rscript. The runner copies
+   the required report, helpers and fixtures into an isolated workspace before
+   rendering. It must never render in the canonical `examples/utility-r` folder.
+4. If dependencies are missing, report the exact missing packages or Pandoc
+   and obtain approval to install them. Do not rebuild the dashboard in another
+   framework to bypass setup.
+5. Check the HTML opens locally, all report tabs are available, and synthetic
+   labels remain visible. Compare key aggregates using the shipped runtime
+   tests/reference assertions, not by reading base64 image blobs.
+6. Provide the HTML path, rerun command and provenance. Ask about customisation
+   only if the user requested it; reproduction itself is a complete result.
+
+Generated synthetic fixture data may be large. Let R read it; inspect source
+code only when diagnosing a specific failure. A screenshot is a visual
+reference, not a substitute for the source or numeric checks.

--- a/frontier-analytics/starter-kits/README.md
+++ b/frontier-analytics/starter-kits/README.md
@@ -10,6 +10,12 @@ For general prerequisites and the overall workflow, see the [Frontier Analytics 
 |-------------|-------------|------------|----------------|
 | [Copilot Adoption Dashboard](copilot-adoption-dashboard/) | Interactive dashboard tracking Copilot adoption metrics over time, including usage trends, feature-level breakdowns, and user segmentation by HR attributes. | Intermediate | HTML dashboard |
 | [Executive Summary Report](executive-summary-report/) | One-page memo summarizing key collaboration and Copilot metrics for executive audiences. Designed for fast turnaround with minimal customization. | Beginner | Markdown / HTML memo |
+| [Consumption Dashboard](consumption-dashboard/) | Reproduce the synthetic reference or adapt documented Consumption exports to a scoped credits report. | Intermediate | HTML + provenance |
+| [Developer Experience Dashboard](developer-experience-dashboard/) | Reproduce/customise the synthetic reference; assess real GitHub inputs without inventing a contract. | Intermediate | Demo HTML or readiness assessment |
+
+The two query-dashboard kits use one [shared R runner](copilot-query-dashboard/).
+They support prompt-only use or an optional skill; no new web application stack
+is needed.
 
 ## What's in a starter kit?
 

--- a/frontier-analytics/starter-kits/consumption-dashboard/README.md
+++ b/frontier-analytics/starter-kits/consumption-dashboard/README.md
@@ -1,0 +1,19 @@
+# Consumption dashboard with an AI agent
+
+Reproduce the existing synthetic Consumption and Ways of Working report, then
+customise it or build a scoped credits report from documented exports.
+
+| Journey | What you receive |
+|---|---|
+| Reproduce demo | Seven-page synthetic HTML, copied source, config and provenance |
+| Adapt documented exports | Credits-only descriptive HTML with privacy suppression, provenance and excluded-panel notes |
+| Extend beyond public schema | An evidence checklist and proposed adapter scope, not invented metrics |
+
+Start with [quickstart.md](quickstart.md) and [required-inputs.md](required-inputs.md).
+The [prompt card](../../prompts/copilot-dashboards/consumption-dashboard.md)
+works without installing a skill. For repeated work, use the
+[optional dashboard skill](../../skills/README.md#dashboard-skill-installation).
+
+The [shared runner](../copilot-query-dashboard/README.md) is the sole runtime
+and configuration reference. This kit does not duplicate the report or data.
+No benchmarked token or time reduction is claimed.

--- a/frontier-analytics/starter-kits/consumption-dashboard/quickstart.md
+++ b/frontier-analytics/starter-kits/consumption-dashboard/quickstart.md
@@ -1,0 +1,24 @@
+# Quickstart
+
+1. Open a local checkout of this repository in your approved coding agent.
+   Keep customer files outside it. Record the checkout revision.
+2. Copy the [Consumption prompt](../../prompts/copilot-dashboards/consumption-dashboard.md)
+   and choose **demo** for the first run. Give the checkout and a new output
+   directory; no customer data is needed.
+3. Let the agent read the [runner's configuration examples](../copilot-query-dashboard/README.md)
+   and run `dashboard.R reproduce <config.json>` using Rscript. It checks the
+   dependencies and renders copied sources, not the canonical example.
+4. Open the HTML. Confirm the synthetic window and labels, seven report pages,
+   readable charts and methodology. Keep the copied source and provenance.
+5. Ask for a focused change such as "move the consumption distribution before
+   the summary, without changing the metrics." The agent edits the copied Rmd.
+
+For real exports, create a separate **real** config and output directory.
+Use `dashboard.R inspect <config.json>`, review its supported/excluded analysis
+list, then approve explicit mappings before `dashboard.R build <config.json>`.
+See the runner README for paths and approval fields; commands are run from
+the shared runner directory or by supplying its full path.
+
+Missing token or task-type fields exclude those panels. Do not translate
+credits into actions, dollars or tokens. If a required contract is unknown,
+finish with a readiness assessment rather than a misleading dashboard.

--- a/frontier-analytics/starter-kits/consumption-dashboard/required-inputs.md
+++ b/frontier-analytics/starter-kits/consumption-dashboard/required-inputs.md
@@ -1,0 +1,22 @@
+# Required inputs
+
+## Reproduce the synthetic demo
+
+- Repository checkout containing the Rmd and `_data/consumption` fixtures.
+- R, Pandoc and packages checked by the shared runner (including `ggrepel`).
+- A new output workspace; do not point it at the repository or a data directory.
+
+## Build the documented credits-only report
+
+- Extracted Consumption activity CSV and people-metadata CSV.
+- Query grain (day/week/month), selected date window and approved group column.
+- Confirmed mappings for person/service/date, historical people key and credits.
+- Unique source keys, valid credit values and metadata matches.
+- Explicit user approval of source evidence, mapping and scoped output.
+- Minimum privacy group size of 10 distinct people, or a stricter policy.
+
+See the [shared contract](../../skills/viva-insights-analysis/reference/copilot-query-contracts.md)
+and [runner config schema](../copilot-query-dashboard/README.md).
+There is no required token field for the credits-only path. Person Query
+associations, task types and policy-limit analyses are not part of that adapter.
+Do not assume every person is observed just because they appear in metadata.

--- a/frontier-analytics/starter-kits/copilot-adoption-dashboard/quickstart.md
+++ b/frontier-analytics/starter-kits/copilot-adoption-dashboard/quickstart.md
@@ -1,6 +1,7 @@
 # Quickstart — Copilot Adoption Dashboard
 
-Get a working Copilot adoption dashboard in under 5 minutes.
+Build a Copilot adoption dashboard with a coding agent. Runtime depends on data,
+dependencies and the agent; no fixed completion time is guaranteed.
 
 ## What you need
 
@@ -28,7 +29,7 @@ In your coding agent, type a brief context line and then paste the prompt:
 ```
 My person query CSV is at ./data/person-query.csv.
 The date column is MetricDate and the primary org column is Organization.
-Use Python with plotly for charts.
+Use Python with matplotlib for static charts embedded in self-contained HTML.
 
 [paste the full Dashboard Overview prompt here]
 ```
@@ -69,7 +70,7 @@ Once the core dashboard is working:
 |---|---|
 | Agent can't find the CSV | Provide the full absolute path to the file. |
 | Column names don't match | Prepend: _"In my data, the org column is called `Org` and the date column is `Date`."_ |
-| Charts are blank | Ensure `plotly` (Python) or `htmlwidgets` (R) is installed in the environment. |
+| Charts are blank | Check the plotting/rendering dependencies reported by the script: matplotlib for the Python path, or ggplot2 and rmarkdown for R. |
 | Too few data points | Confirm your export covers at least 4 weeks and includes Copilot metric columns. |
 | HTML file is very large | Ask the agent to downsample or aggregate data before charting. |
 

--- a/frontier-analytics/starter-kits/copilot-query-dashboard/README.md
+++ b/frontier-analytics/starter-kits/copilot-query-dashboard/README.md
@@ -1,0 +1,207 @@
+# Copilot query dashboard — executable R starter
+
+Three independent commands support inspection, isolated reference reproduction,
+and a deliberately modest real-data credit report. No model-generated report code,
+network data connections, synthetic fallback, or edits to source reports are needed.
+
+```powershell
+Rscript frontier-analytics/starter-kits/copilot-query-dashboard/dashboard.R inspect <config.json>
+Rscript frontier-analytics/starter-kits/copilot-query-dashboard/dashboard.R reproduce <config.json>
+Rscript frontier-analytics/starter-kits/copilot-query-dashboard/dashboard.R build <config.json>
+```
+
+Run from the repository root, or use the entry point's absolute path. On Windows,
+replace `Rscript` with `& 'C:\Program Files\R\R-4.6.1\bin\Rscript.exe'` if needed.
+
+## Dependencies
+
+Inspect/build use base R plus **jsonlite** and Git. Reproduction additionally
+uses the reference reports' installed packages: rmarkdown, flexdashboard, dplyr,
+tidyr, ggplot2, scales, knitr, stringr, vivainsights, and **ggrepel** for Consumption.
+Pandoc is required only for reproduction; rmarkdown discovers it, or set
+`RSTUDIO_PANDOC` to the folder containing an existing `pandoc` executable.
+The CLI reports missing dependencies but never installs them automatically.
+
+## Choose an action
+
+| Action | Mode | Support | Outputs below `output_dir` |
+|---|---|---|---|
+| `inspect` | demo | Checks clean reference inputs; no synthetic generator runs | `inspect/readiness.json` |
+| `inspect` | real | Bounded schema/count summary; Consumption mapping/readiness validation; GitHub blocker | `inspect/readiness.json` |
+| `reproduce` | demo **only** | Complete supplied Consumption or GitHub reference dashboard | `reproduce/dashboard.html`, `reproduce/provenance.json`, isolated `reproduce/work/` |
+| `build` | real **only** | Consumption credits by period, service, optional group | `build/dashboard.html`, `build/aggregates.csv`, `build/provenance.json` |
+
+Each action works without another action's artifacts. Each action directory must
+not already exist: the CLI refuses to overwrite it, even after a failed run.
+Inspect then build can use the same `output_dir`; reruns require a new directory.
+Outputs must be **outside the repository** and cannot contain configured inputs.
+Existing path ancestors are canonicalized before containment checks. Dot segments
+(`.` or `..`) after nonexistent folders are rejected: use an absolute output path
+without unresolved dot segments. Rejection happens before creating any directory.
+Keep outputs in a private, access-controlled workspace; inspection and provenance
+are local analyst artifacts, not automatically approved for distribution.
+
+### Demo journeys
+
+```powershell
+Rscript frontier-analytics/starter-kits/copilot-query-dashboard/dashboard.R reproduce frontier-analytics/starter-kits/copilot-query-dashboard/configs/demo-consumption.json
+Rscript frontier-analytics/starter-kits/copilot-query-dashboard/dashboard.R reproduce frontier-analytics/starter-kits/copilot-query-dashboard/configs/demo-github.json
+```
+
+The supplied configs put results in a sibling `copilot-dashboard-work` directory.
+They reproduce the complete **synthetic** references, not the smaller real adapter.
+Demo configuration accepts no data filters or mapping approvals and requires the
+references' fixed privacy minimum of 10; it never pretends custom settings were applied.
+Consumption copies only its five supplied fixture CSVs and Rmd. GitHub copies
+its Rmd and synthetic helper, which writes generated CSVs only inside the isolated
+work folder. Only tracked, unmodified reference files are accepted; never replace
+demo fixtures with customer data. Rendering and intermediate files stay in the
+work/output folder, and original hashes are checked after rendering.
+
+The full reference reports contain illustrative measures and narratives that are
+**not** verified real-query fields or real-world findings. In particular, the
+Consumption demo's tokens/task types cannot be inferred from the official export.
+
+## Exact JSON configuration
+
+All paths resolve **relative to the JSON file**, never to the shell working
+directory. Absolute paths are accepted. JSON Windows paths need escaped backslashes
+(`"C:\\private\\activity.csv"`); forward slashes also work in JSON paths.
+If you move an example config, update its paths. Do not commit private configs/data.
+
+| Field | Contract |
+|---|---|
+| `report` | Required: `"consumption"` or `"github"` |
+| `mode` | Required: `"demo"` or `"real"` |
+| `repo_root` | Required path to the Git checkout containing the references |
+| `output_dir` | Required private folder outside both `repo_root` and this runtime's repository |
+| `inputs` | Real only. Object with `activity` and (for Consumption) `people` CSV paths. GitHub inspection accepts activity plus optional people. No Person Query adapter. |
+| `mappings` | Real Consumption only: exact source-column mappings below; no normalization or fuzzy guessing |
+| `mapping_approval` | Build requires `{"approved":true,"evidence":"reviewed contract or approval reference"}`. Inspection validates structure without approval. |
+| `granularity` | Consumption validation/build requires `"day"`, `"week"` or `"month"` matching the export; no inference/rebucketing |
+| `dates` | Optional inclusive **period-label** filter: `{"start":"YYYY-MM-DD","end":"YYYY-MM-DD"}` |
+| `group` | Optional boolean, default `false`; `true` requires the metadata group mapping |
+| `privacy_min` | Optional integer >=10, default 10; demo references require exactly 10 |
+
+Required Consumption mappings:
+
+```json
+{
+  "mappings": {
+    "activity": {
+      "person_id": "PersonId",
+      "service_id": "ServiceId",
+      "date": "MetricDate",
+      "people_id": "PeopleHistoricalId",
+      "credits": "Total Copilot Credits used"
+    },
+    "people": {
+      "people_id": "PeopleHistoricalId",
+      "licensed": "IsCopilotLicensed",
+      "group": "Organization"
+    }
+  }
+}
+```
+
+Omit `mappings.people.group` when `group` is false. Mapping objects must have exactly
+the required fields, each pointing to a distinct, exact existing source column.
+`configs/real-consumption.example.json` deliberately starts with approval **false**.
+Inspect it with local paths and explicit mappings while approval is false or
+absent. Inspection validates numeric/date values, keys, joins and declared grain,
+then reports `status: "awaiting_approval"`, `structural_validation: "passed"`,
+`supported_panels`, `excluded_panels`, `privacy_status` and `next_action`.
+Structural validation does not independently establish a source's business semantics:
+review the export contract, declared credits unit and selected group/grain/window.
+Only **after the user's decision**, set approval to true and record the decision
+reference in `evidence` before build. Inspection never changes the approval.
+
+Invalid structure produces `status: "blocked"` even when approval is absent.
+If privacy withholds the release or the window has no records, supported panels
+are empty and the next action is to review scope/coverage, not to publish.
+Approval never bypasses privacy. Inspection writes blockers into readiness.json
+rather than pretending an adapter is ready. Its successful exit means inspection
+completed, not build approval.
+
+## Real Consumption contract and limitations
+
+Grounding: [Microsoft Learn: custom consumption query](https://learn.microsoft.com/en-us/viva/insights/advanced/analyst/ai-cost-query)
+(checked 11 September 2026). The activity key is **PersonId + ServiceId + MetricDate**.
+Activity joins metadata on **PeopleHistoricalId**, not PersonId. Metadata must
+have unique PeopleHistoricalId and explicit **IsCopilotLicensed** (`true`/`false`,
+case-insensitive). This adapter validates licensing metadata but does not report
+licensed denominators or infer licensing from activity.
+
+The current official metrics include **Total Copilot Credits used**, **Session
+count**, **User limit**, and **Spending policy limit**. This version deliberately
+uses only credits. It does not sum limits, infer tokens/task types, or treat credits
+as currency. Extra unmapped columns are ignored, not reverse-engineered.
+
+Build rejects duplicate activity or metadata keys, one historical ID assigned to
+multiple people, unmatched metadata (even without grouping), missing/padded IDs,
+missing groups, invalid dates, negative/nonfinite/malformed credits, ambiguous
+mappings and schema-normalization collisions. CSVs must be UTF-8, comma separated
+with headers; empty cells are missing, credits use decimal points and optional
+scientific notation, and dates are strict ISO dates. There is no `keep first`,
+imputation, automatic deduplication, metric alias inference or demo fallback.
+Validation covers the entire input before applying the date filter.
+
+Output grain is **source MetricDate label × ServiceId × group** (or all people).
+Date filtering does not split weekly/monthly periods. Ensure full periods and
+coverage in the source export: missing periods are not silently filled with zeros.
+No individual ranks, causal/ROI/productivity/burnout claims, or Person Query joins
+are produced. The HTML is a self-contained, accessible aggregate table, not a
+recreation of the synthetic report's seven-page story.
+Its header displays the selected period-label window, observed released period
+range, and generation timestamp in UTC (the same timestamp as provenance).
+For suppressed releases, the observed range is withheld too; an empty window is
+explicitly labeled as having no observations.
+
+### Privacy and output safety
+
+Every displayed cell requires at least `privacy_min` **distinct PersonIds**,
+including people with zero credits present in that source cell. Activity rows and
+historical metadata versions are never treated as distinct people. If **any** cell
+is too small, the **entire release table** is withheld, including its labels,
+counts and credits. There are no grand totals/marginal tables that expose hidden
+composition by subtraction. Empty/suppressed runs still produce an explanatory
+HTML, a header-only CSV and provenance.
+
+This is a conservative single-release rule, **not differential privacy**.
+Review overlapping windows, separate reports and external information together
+before publication; repeated releases can enable differencing. Inspect prints
+only bounded column names (80 columns, 120 characters each), counts, key/grain
+description and date range, never sample records, IDs, service values or HR values.
+HTML escapes labels; spreadsheet-formula-like CSV service/group labels receive a
+leading apostrophe. The CSV contains only the released aggregates.
+
+## Real GitHub: inspect only
+
+Use `configs/real-github-inspect.example.json` with your local export. Its schema
+is **not assumed to match the synthetic helper**. Build stops with an actionable
+blocker until an approved adapter establishes fields, grain, identity, eligibility,
+coverage and semantics. No fabricated “verified GitHub adapter” is provided.
+
+## Reproducibility and tests
+
+Readiness embeds provenance; build/reproduce write it separately. It records
+explicit real/synthetic mode, repository HEAD, **MD5 content checksums** of input
+and runtime files, loaded package versions, R version, configuration mappings,
+approval reference, privacy rule and UTC execution time. Demo provenance also
+records Pandoc and isolated work-file hashes. MD5 is a reproducibility checksum,
+not an authenticity/security guarantee. Real raw records and input absolute paths
+are not copied into provenance. Do not put customer values into approval text.
+
+Run existing base-R assertions (no new test framework):
+
+```powershell
+Rscript frontier-analytics/starter-kits/copilot-query-dashboard/tests/run-tests.R C:\private\test-results
+# Optional: also render both references and verify original file hashes:
+Rscript frontier-analytics/starter-kits/copilot-query-dashboard/tests/run-tests.R C:\private\test-results --render-demos
+```
+
+The output parent must already exist outside the repository. Tests generate small,
+explicitly synthetic CSV cases there, exercise validation, aggregate totals,
+whole-table suppression, output isolation, escaping and mode separation, and write
+`dashboard-tests-<timestamp>/test-results.txt`. Fixtures and generated test artifacts
+are never placed in the source tree.

--- a/frontier-analytics/starter-kits/copilot-query-dashboard/configs/demo-consumption.json
+++ b/frontier-analytics/starter-kits/copilot-query-dashboard/configs/demo-consumption.json
@@ -1,0 +1,7 @@
+{
+  "report": "consumption",
+  "mode": "demo",
+  "repo_root": "../../../..",
+  "output_dir": "../../../../../copilot-dashboard-work/consumption-demo",
+  "privacy_min": 10
+}

--- a/frontier-analytics/starter-kits/copilot-query-dashboard/configs/demo-github.json
+++ b/frontier-analytics/starter-kits/copilot-query-dashboard/configs/demo-github.json
@@ -1,0 +1,7 @@
+{
+  "report": "github",
+  "mode": "demo",
+  "repo_root": "../../../..",
+  "output_dir": "../../../../../copilot-dashboard-work/github-demo",
+  "privacy_min": 10
+}

--- a/frontier-analytics/starter-kits/copilot-query-dashboard/configs/real-consumption.example.json
+++ b/frontier-analytics/starter-kits/copilot-query-dashboard/configs/real-consumption.example.json
@@ -1,0 +1,35 @@
+{
+  "report": "consumption",
+  "mode": "real",
+  "repo_root": "../../../..",
+  "output_dir": "../../../../../copilot-dashboard-work/real-consumption",
+  "inputs": {
+    "activity": "../../../../../private-inputs/PersonServiceCreditsMetrics.csv",
+    "people": "../../../../../private-inputs/PeopleMetaData.csv"
+  },
+  "mappings": {
+    "activity": {
+      "person_id": "PersonId",
+      "service_id": "ServiceId",
+      "date": "MetricDate",
+      "people_id": "PeopleHistoricalId",
+      "credits": "Total Copilot Credits used"
+    },
+    "people": {
+      "people_id": "PeopleHistoricalId",
+      "licensed": "IsCopilotLicensed",
+      "group": "Organization"
+    }
+  },
+  "mapping_approval": {
+    "approved": false,
+    "evidence": "REPLACE with analyst-reviewed export contract or approval reference; do not insert customer records."
+  },
+  "granularity": "day",
+  "dates": {
+    "start": "2026-06-01",
+    "end": "2026-06-30"
+  },
+  "group": true,
+  "privacy_min": 10
+}

--- a/frontier-analytics/starter-kits/copilot-query-dashboard/configs/real-github-inspect.example.json
+++ b/frontier-analytics/starter-kits/copilot-query-dashboard/configs/real-github-inspect.example.json
@@ -1,0 +1,10 @@
+{
+  "report": "github",
+  "mode": "real",
+  "repo_root": "../../../..",
+  "output_dir": "../../../../../copilot-dashboard-work/real-github",
+  "inputs": {
+    "activity": "../../../../../private-inputs/github-export.csv"
+  },
+  "privacy_min": 10
+}

--- a/frontier-analytics/starter-kits/copilot-query-dashboard/dashboard.R
+++ b/frontier-analytics/starter-kits/copilot-query-dashboard/dashboard.R
@@ -1,0 +1,23 @@
+#!/usr/bin/env Rscript
+# Deterministic entry point; synthetic reference code is reachable only through reproduce.
+args <- commandArgs(trailingOnly = FALSE)
+script <- sub("^--file=", "", args[grepl("^--file=", args)])
+if (length(script) != 1L) stop("Run this entry point with Rscript.", call. = FALSE)
+kit <- dirname(normalizePath(script, winslash = "/", mustWork = TRUE))
+source(file.path(kit, "lib", "runtime.R"), local = TRUE)
+status <- tryCatch({
+  cli <- commandArgs(trailingOnly = TRUE)
+  if (length(cli) != 2L || !cli[1] %in% c("inspect", "reproduce", "build"))
+    fail("Usage: Rscript dashboard.R <inspect|reproduce|build> <config.json>")
+  run_dashboard(cli[1], cli[2], kit)
+  0L
+}, dashboard_error = function(e) {
+  cat("BLOCKED: ", conditionMessage(e), "\n", sep = "", file = stderr())
+  1L
+}, error = function(e) {
+  # Parser and package exceptions can include source records or identifiers.
+  cat("BLOCKED: execution failed. Check CSV syntax, file access, and documented dependencies locally.\n",
+      file = stderr())
+  1L
+})
+quit(status = status)

--- a/frontier-analytics/starter-kits/copilot-query-dashboard/lib/runtime.R
+++ b/frontier-analytics/starter-kits/copilot-query-dashboard/lib/runtime.R
@@ -85,8 +85,10 @@ read_config <- function(path, kit) {
         anyDuplicated(names(cfg$inputs)) || any(!names(cfg$inputs) %in% c("activity", "people")))
       fail("inputs accepts only activity and people CSV paths; Person Query is not supported.")
     cfg$inputs <- lapply(cfg$inputs, resolve_path, base = base, existing = TRUE)
-    if (any(vapply(cfg$inputs, function(p) inside(p, cfg$output_dir), logical(1))))
-      fail("Input files cannot be inside output_dir.")
+    unsafe_input <- vapply(cfg$inputs, function(p)
+      inside(p, cfg$output_dir) || inside(p, cfg$repo_root) || inside(p, actual_repo), logical(1))
+    if (any(unsafe_input))
+      fail("Input files must be outside output_dir and both source repositories.")
   }
   cfg
 }

--- a/frontier-analytics/starter-kits/copilot-query-dashboard/lib/runtime.R
+++ b/frontier-analytics/starter-kits/copilot-query-dashboard/lib/runtime.R
@@ -1,0 +1,463 @@
+fail <- function(message) {
+  stop(structure(list(message = message, call = NULL),
+                 class = c("dashboard_error", "error", "condition")))
+}
+
+need <- function(packages) {
+  absent <- packages[!vapply(packages, requireNamespace, logical(1), quietly = TRUE)]
+  if (length(absent)) fail(paste("Missing R packages:", paste(absent, collapse = ", ")))
+}
+
+scalar_text <- function(x) {
+  is.character(x) && length(x) == 1L && !is.na(x) && nzchar(trimws(x))
+}
+
+resolve_path <- function(path, base, existing = FALSE) {
+  if (!scalar_text(path)) fail("Every path must be a nonempty string.")
+  absolute <- grepl("^([A-Za-z]:[/\\\\]|[/\\\\])", path)
+  path <- if (absolute) path else file.path(base, path)
+  if (file.exists(path)) return(normalizePath(path, winslash = "/", mustWork = TRUE))
+  if (existing) fail("A configured input or repository path does not exist.")
+  if (basename(path) %in% c(".", ".."))
+    fail("Unresolved output path contains a dot segment. Use an absolute path without '.' or '..' after nonexistent folders.")
+  parent <- dirname(path)
+  if (identical(parent, path)) fail("Cannot resolve output path.")
+  file.path(resolve_path(parent, base, FALSE), basename(path))
+}
+
+inside <- function(path, parent) {
+  path <- tolower(gsub("\\\\", "/", path))
+  parent <- sub("/+$", "", tolower(gsub("\\\\", "/", parent)))
+  identical(path, parent) || startsWith(path, paste0(parent, "/"))
+}
+
+strict_date <- function(x) {
+  shape <- !is.na(x) & grepl("^[0-9]{4}-[0-9]{2}-[0-9]{2}$", x)
+  result <- suppressWarnings(as.Date(ifelse(shape, x, NA_character_), "%Y-%m-%d"))
+  if (any(!shape | is.na(result)) || any(format(result, "%Y-%m-%d") != x))
+    fail("Dates must be valid ISO YYYY-MM-DD values.")
+  result
+}
+
+read_config <- function(path, kit) {
+  need("jsonlite")
+  path <- normalizePath(path, winslash = "/", mustWork = TRUE)
+  cfg <- jsonlite::fromJSON(path, simplifyVector = FALSE)
+  allowed <- c("report", "mode", "repo_root", "output_dir", "inputs", "mappings",
+               "mapping_approval", "granularity", "dates", "group", "privacy_min")
+  if (!is.list(cfg) || is.null(names(cfg)) || anyDuplicated(names(cfg)) ||
+      any(!names(cfg) %in% allowed)) fail("Unknown or duplicate configuration fields.")
+  if (!scalar_text(cfg$report) || !cfg$report %in% c("consumption", "github"))
+    fail("report must be consumption or github.")
+  if (!scalar_text(cfg$mode) || !cfg$mode %in% c("demo", "real"))
+    fail("mode must be demo or real.")
+  base <- dirname(path)
+  cfg$repo_root <- resolve_path(cfg$repo_root, base, TRUE)
+  cfg$output_dir <- resolve_path(cfg$output_dir, base)
+  actual_repo <- normalizePath(file.path(kit, "..", "..", ".."), winslash = "/", mustWork = TRUE)
+  if (inside(cfg$output_dir, cfg$repo_root) || inside(cfg$output_dir, actual_repo))
+    fail("output_dir must be outside both the source repository and repo_root.")
+  cfg$privacy_min <- if (is.null(cfg$privacy_min)) 10L else cfg$privacy_min
+  if (!is.numeric(cfg$privacy_min) || length(cfg$privacy_min) != 1L ||
+      !is.finite(cfg$privacy_min) || cfg$privacy_min < 10 ||
+      cfg$privacy_min != floor(cfg$privacy_min)) fail("privacy_min must be an integer >= 10.")
+  cfg$group <- if (is.null(cfg$group)) FALSE else cfg$group
+  if (!is.logical(cfg$group) || length(cfg$group) != 1L || is.na(cfg$group))
+    fail("group must be true or false.")
+  if (!is.null(cfg$granularity) && (!scalar_text(cfg$granularity) ||
+      !cfg$granularity %in% c("day", "week", "month")))
+    fail("granularity must be day, week, or month.")
+  if (!is.null(cfg$dates)) {
+    if (!is.list(cfg$dates) || !setequal(names(cfg$dates), c("start", "end")))
+      fail("dates requires start and end.")
+    if (!scalar_text(cfg$dates$start) || !scalar_text(cfg$dates$end))
+      fail("dates requires ISO strings.")
+    bounds <- strict_date(c(cfg$dates$start, cfg$dates$end))
+    if (bounds[1] > bounds[2]) fail("dates.start must not exceed dates.end.")
+  }
+  if (cfg$mode == "demo" && (!is.null(cfg$inputs) || !is.null(cfg$mappings)))
+    fail("Demo mode does not accept real inputs or mappings.")
+  if (cfg$mode == "demo" && (cfg$privacy_min != 10L || cfg$group ||
+      !is.null(cfg$dates) || !is.null(cfg$granularity) || !is.null(cfg$mapping_approval)))
+    fail("Demo reproduces fixed reference settings (privacy_min=10); real-data filters, approvals and custom thresholds do not apply.")
+  if (!is.null(cfg$inputs)) {
+    if (!is.list(cfg$inputs) || is.null(names(cfg$inputs)) ||
+        anyDuplicated(names(cfg$inputs)) || any(!names(cfg$inputs) %in% c("activity", "people")))
+      fail("inputs accepts only activity and people CSV paths; Person Query is not supported.")
+    cfg$inputs <- lapply(cfg$inputs, resolve_path, base = base, existing = TRUE)
+    if (any(vapply(cfg$inputs, function(p) inside(p, cfg$output_dir), logical(1))))
+      fail("Input files cannot be inside output_dir.")
+  }
+  cfg
+}
+
+output_folder <- function(cfg, action) {
+  dest <- file.path(cfg$output_dir, action)
+  if (file.exists(dest)) fail("Action output already exists. Choose a new output_dir; nothing is overwritten.")
+  if (!dir.create(dest, recursive = TRUE, showWarnings = FALSE))
+    fail("Cannot create action output directory.")
+  dest
+}
+
+write_json <- function(value, path) {
+  jsonlite::write_json(value, path, pretty = TRUE, auto_unbox = TRUE, null = "null", na = "null")
+}
+
+file_hashes <- function(paths) {
+  paths <- unlist(paths, use.names = TRUE)
+  values <- unname(tools::md5sum(paths))
+  if (anyNA(values)) fail("Cannot hash an input file.")
+  as.list(setNames(values, names(paths)))
+}
+
+provenance <- function(cfg, action, inputs, kit) {
+  revision <- suppressWarnings(system2("git", c("-C", shQuote(cfg$repo_root), "rev-parse", "HEAD"),
+                                      stdout = TRUE, stderr = FALSE))
+  if (!length(revision) || !grepl("^[a-f0-9]{40}$", revision[1]))
+    fail("repo_root must be a readable Git checkout with a recorded revision.")
+  runtime <- c(entry = file.path(kit, "dashboard.R"), runtime = file.path(kit, "lib", "runtime.R"))
+  versions <- vapply(loadedNamespaces(), function(p) as.character(utils::packageVersion(p)), character(1))
+  list(action = action, report = cfg$report, mode = cfg$mode,
+       synthetic = identical(cfg$mode, "demo"), repository_revision = revision[1],
+       file_hash_algorithm = "MD5 (reproducibility checksum, not authenticity)",
+       input_hashes = file_hashes(inputs), runtime_hashes = file_hashes(runtime),
+       R = R.version.string, packages = as.list(versions),
+       locale = Sys.getlocale(), timezone = Sys.timezone(),
+       generated_utc = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
+       granularity = cfg$granularity, privacy_min = cfg$privacy_min,
+       group = cfg$group, dates = cfg$dates,
+       mapping_approval = cfg$mapping_approval, mappings = cfg$mappings)
+}
+
+read_csv <- function(path) {
+  if (dir.exists(path)) fail("CSV inputs must be files.")
+  fields <- tryCatch(suppressWarnings(utils::count.fields(path, sep = ",", quote = "\"", comment.char = "",
+                                       blank.lines.skip = FALSE)),
+                     error = function(e) fail("Cannot parse CSV input."))
+  if (!length(fields) || is.na(fields[1]) || any(fields[!is.na(fields)] != fields[1]))
+    fail("Malformed CSV: every record must match the header width.")
+  data <- tryCatch(suppressWarnings(utils::read.csv(path, check.names = FALSE, stringsAsFactors = FALSE,
+                                  colClasses = "character", na.strings = "", strip.white = FALSE,
+                                  fileEncoding = "UTF-8-BOM", comment.char = "", fill = FALSE)),
+                   error = function(e) fail("Cannot parse CSV input."))
+  normalized <- tolower(gsub("[^[:alnum:]]", "", names(data)))
+  if (!ncol(data) || any(!nzchar(normalized)) || anyDuplicated(normalized))
+    fail("Schema contains empty names, duplicate names, or normalization collisions.")
+  data
+}
+
+mapped <- function(data, mapping, required) {
+  if (!is.list(mapping) || is.null(names(mapping)) || anyDuplicated(names(mapping)) ||
+      !setequal(names(mapping), required) ||
+      !all(vapply(mapping, scalar_text, logical(1))))
+    fail("Explicit mappings must contain exactly the documented required fields.")
+  columns <- unlist(mapping, use.names = FALSE)
+  if (anyDuplicated(columns)) fail("Two mapped fields cannot use the same source column.")
+  if (!all(columns %in% names(data))) fail("A mapped source column is absent; review the schema.")
+  data <- data[, columns, drop = FALSE]
+  names(data) <- names(mapping)
+  data[, required, drop = FALSE]
+}
+
+require_ids <- function(data, columns) {
+  for (column in columns) {
+    x <- data[[column]]
+    if (anyNA(x) || any(!nzchar(trimws(x))) || any(trimws(x) != x))
+      fail("Required identifiers/attributes are missing, blank, or padded with whitespace.")
+  }
+}
+
+has_mapping_approval <- function(cfg) {
+  approval <- cfg$mapping_approval
+  is.list(approval) && identical(approval$approved, TRUE) && scalar_text(approval$evidence)
+}
+
+validate_consumption <- function(cfg, tables, require_approval = TRUE) {
+  if (is.null(cfg$granularity)) fail("Declare export granularity explicitly: day, week, or month.")
+  if (require_approval && !has_mapping_approval(cfg))
+    fail("mapping_approval requires approved=true and a nonempty evidence reference.")
+  if (!is.list(cfg$mappings) || !setequal(names(cfg$mappings), c("activity", "people")))
+    fail("Consumption requires explicit activity and people mappings.")
+  if (is.null(tables$activity) || is.null(tables$people))
+    fail("Consumption requires both activity and people metadata CSVs.")
+  a <- mapped(tables$activity, cfg$mappings$activity,
+              c("person_id", "service_id", "date", "people_id", "credits"))
+  required <- c("people_id", "licensed", if (cfg$group) "group")
+  p <- mapped(tables$people, cfg$mappings$people, required)
+  require_ids(a, c("person_id", "service_id", "people_id"))
+  require_ids(p, c("people_id", if (cfg$group) "group"))
+  a$date <- strict_date(a$date)
+  if (anyDuplicated(a[c("person_id", "service_id", "date")]))
+    fail("Duplicate activity key: expected one row per PersonId, ServiceId, MetricDate.")
+  if (anyDuplicated(p$people_id)) fail("Duplicate PeopleHistoricalId in metadata; join is ambiguous.")
+  links <- unique(a[c("people_id", "person_id")])
+  if (anyDuplicated(links$people_id))
+    fail("One PeopleHistoricalId maps to multiple PersonIds; join is ambiguous.")
+  if (anyNA(a$credits) ||
+      any(!grepl("^[+]?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$", a$credits)))
+    fail("Credits must be nonnegative finite numbers with a decimal point, not locale separators.")
+  a$credits <- suppressWarnings(as.numeric(a$credits))
+  if (any(!is.finite(a$credits)) || any(a$credits < 0))
+    fail("Credits must be nonnegative finite numbers.")
+  if (anyNA(p$licensed) || any(!tolower(p$licensed) %in% c("true", "false")))
+    fail("IsCopilotLicensed must contain explicit true/false values; activity does not establish licensing.")
+  match_id <- match(a$people_id, p$people_id)
+  if (anyNA(match_id)) fail("Activity contains unmatched people metadata; obtain a complete matching export.")
+  if (cfg$group) a$group <- p$group[match_id] else a$group <- "All people"
+  # Privacy counts people, never metadata versions or activity rows.
+  if (!is.null(cfg$dates)) {
+    start <- strict_date(cfg$dates$start)
+    end <- strict_date(cfg$dates$end)
+    a <- a[a$date >= start & a$date <= end, , drop = FALSE]
+  }
+  a
+}
+
+aggregate_credits <- function(data, threshold) {
+  empty <- data.frame(date = character(), service = character(), group = character(),
+                      people = integer(), credits = numeric(), stringsAsFactors = FALSE)
+  if (!nrow(data)) return(list(status = "no_data", table = empty))
+  keys <- unique(data[c("date", "service_id", "group")])
+  result <- lapply(seq_len(nrow(keys)), function(i) {
+    rows <- data$date == keys$date[i] & data$service_id == keys$service_id[i] &
+      data$group == keys$group[i]
+    data.frame(date = as.character(keys$date[i]), service = keys$service_id[i],
+               group = keys$group[i], people = length(unique(data$person_id[rows])),
+               credits = sum(data$credits[rows]), stringsAsFactors = FALSE)
+  })
+  out <- do.call(rbind, result)
+  if (any(!is.finite(out$credits))) fail("Aggregated credits overflow; no output is publishable.")
+  # Conservative whole-release suppression prevents subtraction across displayed slices.
+  if (any(out$people < threshold)) return(list(status = "suppressed", table = empty))
+  out <- out[order(out$date, out$service, out$group), , drop = FALSE]
+  rownames(out) <- NULL
+  list(status = "ready", table = out)
+}
+
+schema_summary <- function(data) {
+  cols <- head(names(data), 80L)
+  clean <- function(x) substr(gsub("[[:cntrl:]]", "", x), 1L, 120L)
+  list(rows = nrow(data), columns = ncol(data), displayed_columns = clean(cols),
+       schema_truncated = ncol(data) > 80L,
+       missing_cells = sum(is.na(data) | data == ""))
+}
+
+reference_files <- function(cfg) {
+  utility <- file.path(cfg$repo_root, "examples", "utility-r")
+  if (cfg$report == "github") {
+    relative <- c("github-copilot-developer-productivity-simulation.Rmd",
+                  "github-developer-experience-helpers.R")
+  } else {
+    relative <- c("copilot-consumption-ways-of-working-simulation.Rmd",
+                  file.path("_data", "consumption", c(
+                    "reference/people-snapshot.csv",
+                    "consumption-query/consumption-weekly.csv",
+                    "consumption-query/consumption-task-types.csv",
+                    "person-query/person-query-weekly.csv",
+                    "person-query/network-monthly.csv")))
+  }
+  paths <- file.path(utility, relative)
+  if (!all(file.exists(paths))) fail("Reference report or supplied synthetic fixtures are missing.")
+  # Only clean tracked reference files may execute as synthetic code/data.
+  for (path in paths) {
+    rel <- substring(gsub("\\\\", "/", path), nchar(cfg$repo_root) + 2L)
+    tracked <- suppressWarnings(system2("git", c("-C", shQuote(cfg$repo_root), "ls-files",
+                                                "--error-unmatch", "--", shQuote(rel)),
+                                       stdout = TRUE, stderr = FALSE))
+    dirty <- suppressWarnings(system2("git", c("-C", shQuote(cfg$repo_root), "status",
+                                              "--porcelain", "--", shQuote(rel)),
+                                     stdout = TRUE, stderr = FALSE))
+    if (!length(tracked) || !is.null(attr(tracked, "status")) || length(dirty))
+      fail("Demo reference files must be tracked and unmodified; do not replace fixtures with customer data.")
+  }
+  setNames(paths, relative)
+}
+
+inspect_dashboard <- function(cfg, kit) {
+  inputs <- if (cfg$mode == "demo") reference_files(cfg) else cfg$inputs
+  if (is.null(inputs) || !length(inputs)) fail("Real inspection requires inputs.activity (and optionally people).")
+  before <- file_hashes(inputs)
+  csv_inputs <- if (cfg$mode == "demo") inputs[grepl("\\.csv$", inputs, ignore.case = TRUE)] else inputs
+  tables <- lapply(csv_inputs, read_csv)
+  report <- list(report = cfg$report, mode = cfg$mode, synthetic = cfg$mode == "demo",
+                 schema = lapply(tables, schema_summary), status = "inspect_only")
+  if (cfg$mode == "demo") {
+    report$next_action <- "reproduce: isolated synthetic reference; this is not a verified real-data adapter."
+  } else if (cfg$report == "github") {
+    report$blocker <- "Real GitHub schema/semantics are unverified. Obtain an approved export contract, grain, coverage and mappings; build is unsupported."
+  } else {
+    validation <- tryCatch(validate_consumption(cfg, tables, require_approval = FALSE),
+                           dashboard_error = function(e) e)
+    if (inherits(validation, "dashboard_error")) {
+      report$status <- "blocked"
+      report$blocker <- conditionMessage(validation)
+      report$next_action <- "Correct the structural validation blocker, then inspect again before deciding approval."
+    } else {
+      release <- aggregate_credits(validation, cfg$privacy_min)
+      approved <- has_mapping_approval(cfg)
+      report$status <- if (approved) release$status else "awaiting_approval"
+      report$structural_validation <- "passed"
+      report$approval_status <- if (approved) "approved" else "awaiting_approval"
+      report$privacy_status <- release$status
+      report$supported_panels <- if (release$status == "ready")
+        c("Copilot credits by source period and service",
+          if (cfg$group) "Copilot credits by configured metadata group") else character()
+      report$excluded_panels <- c(
+        "Tokens and task types: absent from the verified Consumption contract",
+        "Sessions, user limits and spending policy limits: not implemented by this credits-only adapter",
+        "Person Query associations and GitHub panels: no verified real-data adapter",
+        "Licensed population denominators, individual ranks, causal/ROI/productivity/burnout claims: unsupported",
+        if (release$status != "ready") "All aggregate panels: withheld by privacy or unavailable in the selected window")
+      report$grain <- paste("PersonId + ServiceId + MetricDate;", cfg$granularity, "export periods")
+      report$metric_unit <- "Copilot credits, as explicitly mapped; not currency. Confirm source semantics before approval."
+      report$rows_in_window <- nrow(validation)
+      report$distinct_people <- length(unique(validation$person_id))
+      report$date_range <- if (nrow(validation)) as.character(range(validation$date)) else character()
+      report$next_action <- if (release$status == "suppressed") {
+        "All aggregate panels are withheld. Review an appropriately broader source scope and inspect again; approval does not override privacy."
+      } else if (release$status == "no_data") {
+        "Review source coverage and the selected period window, then inspect again; no panels are available."
+      } else if (!approved) {
+        "Review the validated scope, declared units/granularity and excluded panels with the user. Only after their decision, set mapping_approval.approved=true with nonblank evidence, then build."
+      } else {
+        "Build the approved supported panels; no values/identifiers are included in this inspection."
+      }
+    }
+  }
+  report$provenance <- provenance(cfg, "inspect", inputs, kit)
+  if (!identical(before, report$provenance$input_hashes))
+    fail("Inputs changed during inspection; rerun against stable exports.")
+  dest <- output_folder(cfg, "inspect")
+  write_json(report, file.path(dest, "readiness.json"))
+  # Output is bounded; the full schema is already capped and contains no record samples.
+  printable <- report
+  printable$provenance <- NULL
+  cat(jsonlite::toJSON(printable, pretty = TRUE, auto_unbox = TRUE), "\n")
+  invisible(report)
+}
+
+escape_html <- function(x) {
+  x <- gsub("&", "&amp;", as.character(x), fixed = TRUE)
+  x <- gsub("<", "&lt;", x, fixed = TRUE)
+  x <- gsub(">", "&gt;", x, fixed = TRUE)
+  x <- gsub('"', "&quot;", x, fixed = TRUE)
+  gsub("'", "&#39;", x, fixed = TRUE)
+}
+
+dashboard_html <- function(release, cfg,
+                           generated_utc = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")) {
+  text <- switch(release$status,
+                 ready = "Credits by export period, service and group",
+                 suppressed = "All aggregates withheld: at least one cell has fewer than the privacy minimum.",
+                 no_data = "No records in the selected date window.")
+  rows <- if (nrow(release$table)) apply(release$table, 1L, function(row)
+    paste0("<tr><td>", paste(escape_html(row), collapse = "</td><td>"), "</td></tr>")) else character()
+  selected_window <- if (is.null(cfg$dates)) "All supplied source period labels (no date filter)" else
+    paste(cfg$dates$start, "to", cfg$dates$end, "(inclusive source period labels)")
+  observed_window <- if (release$status == "suppressed") "Withheld under the privacy policy" else
+    if (release$status == "ready" && nrow(release$table))
+      paste(range(release$table$date), collapse = " to ") else
+      "No observations in the selected window"
+  paste0('<!doctype html><html lang="en"><head><meta charset="utf-8">',
+         '<meta name="viewport" content="width=device-width,initial-scale=1">',
+         '<title>Copilot credit consumption</title><style>',
+         'body{font:16px system-ui,sans-serif;max-width:1100px;margin:2rem auto;padding:1rem;color:#253047}',
+         'table{border-collapse:collapse;width:100%}td,th{padding:.7rem;text-align:left;border-bottom:1px solid #ddd}',
+         '.scroll{overflow:auto}aside{background:#eef2ff;padding:1rem}small{color:#475569}',
+         '</style></head><body><h1>Copilot credit consumption</h1>',
+         '<p><strong>Real-data aggregate · Provisional · Not a productivity assessment</strong></p>',
+         '<p><strong>Selected period window:</strong> ', escape_html(selected_window),
+         '<br><strong>Observed period window:</strong> ', escape_html(observed_window),
+         '<br><strong>Generated (UTC):</strong> ', escape_html(generated_utc), '</p>',
+         '<p>', escape_html(text), '</p><p>Export granularity: ', cfg$granularity,
+         '. MetricDate is the source period label; periods are not rebucketed or inferred.',
+         ' Privacy minimum: ', cfg$privacy_min, ' distinct people per displayed cell.</p>',
+         '<aside>Credits are consumption units, not currency. Positive activity does not establish licensing.',
+         ' No token counts, task types, policy-limit totals, individual rankings, causal effects, ROI,',
+         ' productivity or burnout claims are calculated. Counts describe people present in activity,',
+         ' not the eligible or licensed population. Missing dates are not filled with zeros.',
+         ' Review partial periods and source coverage before sharing.</aside>',
+         '<div class="scroll"><table><caption>Released aggregates only; no marginal totals</caption>',
+         '<thead><tr><th scope="col">MetricDate</th><th scope="col">ServiceId</th>',
+         '<th scope="col">Group</th><th scope="col">Distinct people</th>',
+         '<th scope="col">Copilot credits</th></tr></thead><tbody>',
+         paste(rows, collapse = ""), '</tbody></table></div>',
+         '<p><small>Read provenance.json for source hashes, repository revision, configuration and package versions.',
+         ' This release uses whole-table suppression; separate releases must be disclosure-reviewed together.</small></p>',
+         '</body></html>')
+}
+
+build_dashboard <- function(cfg, kit) {
+  if (cfg$mode != "real") fail("build is real-only. Use reproduce for synthetic references.")
+  if (cfg$report == "github")
+    fail("Real GitHub build is unsupported: inspect the export and obtain an approved schema, grain and coverage contract.")
+  if (is.null(cfg$inputs$activity) || is.null(cfg$inputs$people))
+    fail("Consumption build requires inputs.activity and inputs.people.")
+  before <- file_hashes(cfg$inputs)
+  tables <- lapply(cfg$inputs, read_csv)
+  data <- validate_consumption(cfg, tables)
+  release <- aggregate_credits(data, cfg$privacy_min)
+  prov <- provenance(cfg, "build", cfg$inputs, kit)
+  if (!identical(before, prov$input_hashes))
+    fail("Inputs changed during build; rerun against stable exports.")
+  prov$release_status <- release$status
+  prov$privacy_policy <- "Withhold the entire table if any date/service/group cell is below privacy_min. No marginal totals."
+  dest <- output_folder(cfg, "build")
+  # Do not serialize pre-suppression counts, raw rows, keys, or group labels.
+  csv <- release$table
+  for (column in c("service", "group")) {
+    dangerous <- grepl("^[[:space:]]*[=+@-]|[\\r\\n\\t]", csv[[column]])
+    csv[[column]][dangerous] <- paste0("'", csv[[column]][dangerous])
+  }
+  utils::write.csv(csv, file.path(dest, "aggregates.csv"), row.names = FALSE,
+                   fileEncoding = "UTF-8")
+  writeLines(dashboard_html(release, cfg, prov$generated_utc),
+             file.path(dest, "dashboard.html"), useBytes = TRUE)
+  write_json(prov, file.path(dest, "provenance.json"))
+  cat("Build completed:", release$status, "(aggregate outputs only).\n")
+  invisible(release)
+}
+
+reproduce_dashboard <- function(cfg, kit) {
+  if (cfg$mode != "demo") fail("reproduce is demo-only and never accepts real inputs.")
+  required <- c("rmarkdown", "flexdashboard", "dplyr", "tidyr", "ggplot2",
+                "scales", "knitr", "stringr", "vivainsights",
+                if (cfg$report == "consumption") "ggrepel")
+  need(required)
+  if (!rmarkdown::pandoc_available()) fail("Pandoc is missing. Set RSTUDIO_PANDOC to an existing Pandoc folder.")
+  inputs <- reference_files(cfg)
+  before <- file_hashes(inputs)
+  dest <- output_folder(cfg, "reproduce")
+  work <- file.path(dest, "work")
+  dir.create(work)
+  for (i in seq_along(inputs)) {
+    target <- file.path(work, names(inputs)[i])
+    dir.create(dirname(target), recursive = TRUE, showWarnings = FALSE)
+    if (!file.copy(inputs[i], target, overwrite = FALSE)) fail("Cannot copy reference into isolated work folder.")
+  }
+  input <- file.path(work, names(inputs)[1])
+  old <- getwd()
+  on.exit(setwd(old), add = TRUE)
+  setwd(work)
+  rmarkdown::render(input, output_file = "dashboard.html", output_dir = dest,
+                    intermediates_dir = work, knit_root_dir = work,
+                    output_options = list(self_contained = TRUE, mathjax = NULL),
+                    envir = new.env(parent = globalenv()), quiet = TRUE)
+  if (!identical(before, file_hashes(inputs))) fail("Source reference changed during reproduction.")
+  prov <- provenance(cfg, "reproduce", inputs, kit)
+  prov$pandoc <- as.character(rmarkdown::pandoc_version())
+  prov$notice <- "Synthetic demonstration only. Reference metrics and illustrative narratives do not verify a real-data contract."
+  generated <- list.files(work, recursive = TRUE, full.names = TRUE)
+  names(generated) <- substring(generated, nchar(work) + 2L)
+  prov$work_hashes <- file_hashes(generated)
+  write_json(prov, file.path(dest, "provenance.json"))
+  cat("Synthetic reference rendered in the isolated reproduce folder. Source files unchanged.\n")
+  invisible(prov)
+}
+
+run_dashboard <- function(action, config_path, kit) {
+  cfg <- read_config(config_path, kit)
+  switch(action, inspect = inspect_dashboard(cfg, kit),
+         reproduce = reproduce_dashboard(cfg, kit), build = build_dashboard(cfg, kit),
+         fail("Unknown action."))
+}

--- a/frontier-analytics/starter-kits/copilot-query-dashboard/lib/runtime.R
+++ b/frontier-analytics/starter-kits/copilot-query-dashboard/lib/runtime.R
@@ -75,6 +75,9 @@ read_config <- function(path, kit) {
     bounds <- strict_date(c(cfg$dates$start, cfg$dates$end))
     if (bounds[1] > bounds[2]) fail("dates.start must not exceed dates.end.")
   }
+  if (cfg$report == "github" && cfg$mode == "real" &&
+      any(c("dates", "group", "granularity", "mappings", "mapping_approval") %in% names(cfg)))
+    fail("Real GitHub inspection does not accept analytical filters, mappings, or approval settings because no verified adapter exists.")
   if (cfg$mode == "demo" && (!is.null(cfg$inputs) || !is.null(cfg$mappings)))
     fail("Demo mode does not accept real inputs or mappings.")
   if (cfg$mode == "demo" && (cfg$privacy_min != 10L || cfg$group ||

--- a/frontier-analytics/starter-kits/copilot-query-dashboard/tests/run-tests.R
+++ b/frontier-analytics/starter-kits/copilot-query-dashboard/tests/run-tests.R
@@ -226,10 +226,26 @@ test("normalization collisions and malformed rows rejected", {
 test("real GitHub inspect only with actionable build blocker", {
   gh <- loaded
   gh$report <- "github"
+  gh$dates <- gh$group <- gh$granularity <- gh$mappings <- gh$mapping_approval <- NULL
   gh$output_dir <- file.path(root, "github-inspect")
   report <- inspect_dashboard(gh, kit)
   stopifnot(report$status == "inspect_only", grepl("unverified", report$blocker))
   blocked(build_dashboard(gh, kit), "unsupported")
+})
+test("real GitHub inspection rejects unapplied analytical settings", {
+  for (field in c("dates", "group", "granularity", "mappings", "mapping_approval")) {
+    gh <- list(report = "github", mode = "real", repo_root = repo,
+               output_dir = file.path(root, paste0("github-", field)),
+               inputs = list(activity = "synthetic-activity.csv"), privacy_min = 10)
+    gh[[field]] <- switch(field,
+      dates = list(start = "2026-06-01", end = "2026-06-02"),
+      group = TRUE,
+      granularity = "day",
+      mappings = cfg$mappings,
+      mapping_approval = cfg$mapping_approval)
+    write_json(gh, paste0("github-", field, ".json"))
+    blocked(read_config(paste0("github-", field, ".json"), kit), "does not accept analytical")
+  }
 })
 test("real mode cannot reproduce and demo mode cannot build", {
   blocked(reproduce_dashboard(loaded, kit), "demo-only")
@@ -301,9 +317,9 @@ test("entry point succeeds from an unrelated working directory", {
 })
 test("entry point rejects unsupported GitHub before producing build output", {
   command <- file.path(R.home("bin"), "Rscript")
-  config <- cfg
-  config$report <- "github"
-  config$output_dir <- file.path(root, "cli-github-block")
+  config <- list(report = "github", mode = "real", repo_root = repo,
+                 output_dir = file.path(root, "cli-github-block"),
+                 inputs = list(activity = "synthetic-activity.csv"), privacy_min = 10)
   write_json(config, "cli-github.json")
   result <- suppressWarnings(system2(command, c(shQuote(file.path(kit, "dashboard.R")), "build",
                                                 shQuote(file.path(root, "cli-github.json"))),

--- a/frontier-analytics/starter-kits/copilot-query-dashboard/tests/run-tests.R
+++ b/frontier-analytics/starter-kits/copilot-query-dashboard/tests/run-tests.R
@@ -1,0 +1,350 @@
+# Base-R regression tests. All generated data below is synthetic.
+# Usage: Rscript tests/run-tests.R <existing-private-test-output-parent> [--render-demos]
+args <- commandArgs(trailingOnly = FALSE)
+script <- sub("^--file=", "", args[grepl("^--file=", args)])
+kit <- normalizePath(file.path(dirname(script), ".."), winslash = "/", mustWork = TRUE)
+source(file.path(kit, "lib", "runtime.R"))
+cli <- commandArgs(trailingOnly = TRUE)
+if (!length(cli)) stop("Supply an existing test-output parent outside the repository.")
+parent <- normalizePath(cli[1], winslash = "/", mustWork = TRUE)
+repo <- normalizePath(file.path(kit, "..", "..", ".."), winslash = "/", mustWork = TRUE)
+if (inside(parent, repo)) stop("Test output must be outside the repository.")
+root <- file.path(parent, paste0("dashboard-tests-", format(Sys.time(), "%Y%m%d-%H%M%S")))
+stopifnot(!file.exists(root), dir.create(root))
+setwd(root)
+need("jsonlite")
+passed <- character()
+test <- function(name, code) {
+  force(code)
+  passed <<- c(passed, name)
+  cat("PASS:", name, "\n")
+}
+blocked <- function(code, pattern) {
+  err <- tryCatch({ force(code); NULL }, dashboard_error = function(e) conditionMessage(e))
+  stopifnot(!is.null(err), grepl(pattern, err, ignore.case = TRUE))
+}
+people <- data.frame(PeopleHistoricalId = sprintf("synthetic-history-%02d", 1:20),
+                     IsCopilotLicensed = rep(c("true", "false"), 10),
+                     Organization = rep(c("Synthetic Alpha", "Synthetic Beta"), each = 10),
+                     check.names = FALSE)
+activity <- expand.grid(PersonId = sprintf("synthetic-person-%02d", 1:20),
+                         ServiceId = c("Synthetic Service A", "Synthetic Service B"),
+                         MetricDate = c("2026-06-01", "2026-06-02"), stringsAsFactors = FALSE)
+activity$PeopleHistoricalId <- people$PeopleHistoricalId[match(activity$PersonId,
+                                                            sprintf("synthetic-person-%02d", 1:20))]
+activity[["Total Copilot Credits used"]] <- rep(1:20, 4)
+activity[["User limit"]] <- 999
+activity[["Spending policy limit"]] <- 99999
+write.csv(activity, "synthetic-activity.csv", row.names = FALSE)
+write.csv(people, "synthetic-people.csv", row.names = FALSE)
+cfg <- list(report = "consumption", mode = "real", repo_root = repo,
+            output_dir = file.path(root, "success"),
+            inputs = list(activity = "synthetic-activity.csv", people = "synthetic-people.csv"),
+            mappings = list(activity = list(person_id = "PersonId", service_id = "ServiceId",
+                                           date = "MetricDate", people_id = "PeopleHistoricalId",
+                                           credits = "Total Copilot Credits used"),
+                            people = list(people_id = "PeopleHistoricalId",
+                                          licensed = "IsCopilotLicensed", group = "Organization")),
+            mapping_approval = list(approved = TRUE, evidence = "Synthetic regression fixture contract"),
+            granularity = "day", group = TRUE, privacy_min = 10)
+write_json(cfg, "config.json")
+loaded <- read_config("config.json", kit)
+tables <- lapply(loaded$inputs, read_csv)
+valid <- validate_consumption(loaded, tables)
+test("relative input paths resolve from config, not working directory", {
+  stopifnot(loaded$inputs$activity == file.path(root, "synthetic-activity.csv"))
+})
+test("credits aggregate by explicit period/service/group with distinct people", {
+  agg <- aggregate_credits(valid, 10)
+  stopifnot(agg$status == "ready", nrow(agg$table) == 8,
+            sum(agg$table$credits) == 840, all(agg$table$people == 10),
+            setequal(agg$table$credits, c(55, 155)))
+})
+test("real build independently produces self-contained aggregate dashboard", {
+  run_dashboard("build", "config.json", kit)
+  stopifnot(file.exists(file.path(loaded$output_dir, "build", "dashboard.html")),
+            file.exists(file.path(loaded$output_dir, "build", "provenance.json")))
+  prov <- jsonlite::read_json(file.path(loaded$output_dir, "build", "provenance.json"))
+  stopifnot(identical(prov$synthetic, FALSE), nchar(prov$repository_revision) == 40,
+            length(prov$input_hashes) == 2)
+})
+test("no invented tokens, sessions, currency or policy-limit totals in aggregates", {
+  csv <- read.csv(file.path(loaded$output_dir, "build", "aggregates.csv"))
+  stopifnot(identical(names(csv), c("date", "service", "group", "people", "credits")),
+            !any(grepl("synthetic-person|synthetic-history", unlist(csv))))
+})
+test("inspect independent of build, no customer rows or values printed", {
+  text <- capture.output(run_dashboard("inspect", "config.json", kit))
+  stopifnot(!any(grepl("Synthetic Alpha|Synthetic Beta|synthetic-person|synthetic-history|Synthetic Service", text)))
+})
+test("unapproved inspection validates structure and provides scope before user approval", {
+  for (approval in list(NULL, list(approved = FALSE, evidence = "Pending decision"),
+                       list(approved = TRUE, evidence = " "))) {
+    pending <- loaded
+    pending$mapping_approval <- approval
+    pending$output_dir <- file.path(root, paste0("pending-", length(list.files(root))))
+    capture.output(report <- inspect_dashboard(pending, kit))
+    stopifnot(report$status == "awaiting_approval", report$structural_validation == "passed",
+              report$privacy_status == "ready", length(report$supported_panels) == 2L,
+              length(report$excluded_panels) >= 4L,
+              grepl("Only after their decision", report$next_action))
+    blocked(build_dashboard(pending, kit), "approval")
+    stopifnot(!dir.exists(file.path(pending$output_dir, "build")))
+  }
+})
+test("unapproved inspection reports key errors instead of an approval blocker", {
+  duplicate <- rbind(activity, activity[1, ])
+  write.csv(duplicate, "unapproved-duplicate.csv", row.names = FALSE)
+  pending <- loaded
+  pending$mapping_approval <- NULL
+  pending$inputs$activity <- file.path(root, "unapproved-duplicate.csv")
+  pending$output_dir <- file.path(root, "pending-invalid")
+  capture.output(report <- inspect_dashboard(pending, kit))
+  stopifnot(report$status == "blocked", grepl("Duplicate activity key", report$blocker),
+            grepl("structural validation", report$next_action))
+})
+test("inspection excludes all panels if privacy fails before approval", {
+  write.csv(activity[-1, ], "unapproved-small.csv", row.names = FALSE)
+  pending <- loaded
+  pending$mapping_approval <- NULL
+  pending$inputs$activity <- file.path(root, "unapproved-small.csv")
+  pending$output_dir <- file.path(root, "pending-small")
+  capture.output(report <- inspect_dashboard(pending, kit))
+  stopifnot(report$status == "awaiting_approval", report$privacy_status == "suppressed",
+            length(report$supported_panels) == 0L,
+            grepl("approval does not override privacy", report$next_action))
+})
+test("real HTML header records selected observed and generation windows", {
+  selected <- loaded
+  selected$dates <- list(start = "2026-05-01", end = "2026-06-30")
+  html <- dashboard_html(aggregate_credits(valid, 10), selected, "2026-09-11T16:00:00Z")
+  stopifnot(grepl("2026-05-01 to 2026-06-30", html),
+            grepl("Observed period window:</strong> 2026-06-01 to 2026-06-02", html, fixed = TRUE),
+            grepl("Generated (UTC):</strong> 2026-09-11T16:00:00Z", html, fixed = TRUE))
+  withheld <- dashboard_html(aggregate_credits(valid[-1, ], 10), selected)
+  stopifnot(grepl("Observed period window:</strong> Withheld", withheld, fixed = TRUE),
+            grepl("2026-05-01 to 2026-06-30", withheld, fixed = TRUE),
+            !grepl("2026-06-01|2026-06-02|Synthetic Alpha|Synthetic Beta|Synthetic Service", withheld))
+  empty <- dashboard_html(aggregate_credits(valid[FALSE, ], 10), selected)
+  stopifnot(grepl("No observations in the selected window", empty, fixed = TRUE))
+  prov <- jsonlite::read_json(file.path(loaded$output_dir, "build", "provenance.json"))
+  generated <- paste(readLines(file.path(loaded$output_dir, "build", "dashboard.html")), collapse = "")
+  stopifnot(grepl(prov$generated_utc, generated, fixed = TRUE))
+})
+test("output overwrite is refused", blocked(run_dashboard("build", "config.json", kit), "already exists"))
+test("duplicate activity keys rejected", {
+  bad <- tables
+  bad$activity <- rbind(bad$activity, bad$activity[1, ])
+  blocked(validate_consumption(loaded, bad), "Duplicate activity")
+})
+test("duplicate metadata rejected rather than keeping first", {
+  bad <- tables
+  bad$people <- rbind(bad$people, bad$people[1, ])
+  blocked(validate_consumption(loaded, bad), "Duplicate PeopleHistoricalId")
+})
+test("unmatched metadata rejected", {
+  bad <- tables
+  bad$people <- bad$people[-1, ]
+  blocked(validate_consumption(loaded, bad), "unmatched")
+})
+test("one historical key cannot represent two people", {
+  bad <- tables
+  bad$activity$PeopleHistoricalId[2] <- bad$activity$PeopleHistoricalId[1]
+  blocked(validate_consumption(loaded, bad), "multiple PersonIds")
+})
+test("negative, missing, NaN, infinite and nonnumeric credits rejected", {
+  for (value in c("-1", NA_character_, "NaN", "Inf", "1e999", "invalid", "1,000")) {
+    bad <- tables
+    bad$activity[["Total Copilot Credits used"]][1] <- value
+    blocked(validate_consumption(loaded, bad), "Credits")
+  }
+})
+test("invalid dates rejected without coercion", {
+  for (value in c("2026-02-30", "06/01/2026", "", "not a date", NA_character_)) {
+    bad <- tables
+    bad$activity$MetricDate[1] <- value
+    blocked(validate_consumption(loaded, bad), "Dates")
+  }
+})
+test("missing IDs and group attributes rejected", {
+  for (field in c("PersonId", "ServiceId", "PeopleHistoricalId")) {
+    bad <- tables
+    bad$activity[[field]][1] <- NA_character_
+    blocked(validate_consumption(loaded, bad), "identifiers")
+  }
+  bad <- tables
+  bad$people$Organization[1] <- ""
+  blocked(validate_consumption(loaded, bad), "attributes")
+})
+test("licensing never inferred from positive activity", {
+  bad <- tables
+  bad$people$IsCopilotLicensed[1] <- NA_character_
+  blocked(validate_consumption(loaded, bad), "licens")
+})
+test("unapproved, incomplete or ambiguous mappings block build", {
+  bad <- loaded
+  bad$mapping_approval$approved <- FALSE
+  blocked(validate_consumption(bad, tables), "approval")
+  bad <- loaded
+  bad$mappings$activity$credits <- "No such column"
+  blocked(validate_consumption(bad, tables), "absent")
+  bad$mappings$activity$credits <- "PersonId"
+  blocked(validate_consumption(bad, tables), "same source")
+})
+test("granularity required and preserved rather than guessed", {
+  bad <- loaded
+  bad$granularity <- NULL
+  blocked(validate_consumption(bad, tables), "granularity")
+  for (grain in c("day", "week", "month")) {
+    bad$granularity <- grain
+    stopifnot(identical(validate_consumption(bad, tables)$date, valid$date))
+  }
+})
+test("privacy uses distinct people, not records or historical versions", {
+  repeated <- valid[rep(1, 20), ]
+  stopifnot(aggregate_credits(repeated, 10)$status == "suppressed")
+})
+test("one small cell withholds every cell and every composition label", {
+  small <- valid[-1, ]
+  out <- aggregate_credits(small, 10)
+  stopifnot(out$status == "suppressed", nrow(out$table) == 0)
+  html <- dashboard_html(out, loaded)
+  stopifnot(!grepl("Synthetic Alpha|Synthetic Beta|Synthetic Service", html))
+})
+test("empty date window produces no invented zeros", {
+  bad <- loaded
+  bad$dates <- list(start = "2025-01-01", end = "2025-01-31")
+  out <- aggregate_credits(validate_consumption(bad, tables), 10)
+  stopifnot(out$status == "no_data", nrow(out$table) == 0)
+})
+test("normalization collisions and malformed rows rejected", {
+  writeLines(c("PersonId,Person_Id", "a,b"), "collision.csv")
+  blocked(read_csv("collision.csv"), "collision")
+  writeLines(c("a,b", "1,2,3"), "bad-width.csv")
+  blocked(read_csv("bad-width.csv"), "header width")
+})
+test("real GitHub inspect only with actionable build blocker", {
+  gh <- loaded
+  gh$report <- "github"
+  gh$output_dir <- file.path(root, "github-inspect")
+  report <- inspect_dashboard(gh, kit)
+  stopifnot(report$status == "inspect_only", grepl("unverified", report$blocker))
+  blocked(build_dashboard(gh, kit), "unsupported")
+})
+test("real mode cannot reproduce and demo mode cannot build", {
+  blocked(reproduce_dashboard(loaded, kit), "demo-only")
+  demo <- loaded
+  demo$mode <- "demo"
+  blocked(build_dashboard(demo, kit), "real-only")
+  write_json(demo, "mixed-config.json")
+  blocked(read_config("mixed-config.json", kit), "does not accept")
+})
+test("privacy below ten and output inside source repo rejected", {
+  bad <- cfg
+  bad$privacy_min <- 9
+  write_json(bad, "bad-privacy.json")
+  blocked(read_config("bad-privacy.json", kit), ">= 10")
+  bad <- cfg
+  bad$output_dir <- file.path(repo, "do-not-create")
+  write_json(bad, "bad-output.json")
+  blocked(read_config("bad-output.json", kit), "outside")
+  stopifnot(!dir.exists(bad$output_dir))
+})
+test("nonexistent output tails cannot traverse into the source repository", {
+  outside <- file.path(dirname(repo), paste0("uncreated-dashboard-path-", Sys.getpid()))
+  stopifnot(!file.exists(outside))
+  bad <- cfg
+  bad$output_dir <- file.path(outside, "new-folder", "..", "..", basename(repo))
+  write_json(bad, "traversal-output.json")
+  blocked(read_config("traversal-output.json", kit), "dot segment|outside")
+  stopifnot(!file.exists(outside), !file.exists(file.path(outside, "new-folder")))
+  bad$output_dir <- file.path(outside, "new-folder", ".", "result")
+  write_json(bad, "dot-output.json")
+  blocked(read_config("dot-output.json", kit), "dot segment")
+  stopifnot(!file.exists(outside))
+})
+test("HTML attribute values escaped and CSV formulas neutralized", {
+  escaped <- aggregate_credits(valid, 10)
+  escaped$table$group <- "<script>alert(1)</script>"
+  stopifnot(!grepl("<script>", dashboard_html(escaped, loaded), fixed = TRUE),
+            grepl("&lt;script&gt;", dashboard_html(escaped, loaded), fixed = TRUE))
+  formula <- people
+  formula$Organization <- "=1+1"
+  write.csv(formula, "formula-people.csv", row.names = FALSE)
+  bad <- loaded
+  bad$inputs$people <- file.path(root, "formula-people.csv")
+  bad$output_dir <- file.path(root, "formula-build")
+  build_dashboard(bad, kit)
+  csv <- read.csv(file.path(bad$output_dir, "build", "aggregates.csv"))
+  stopifnot(all(csv$group == "'=1+1"))
+})
+test("demo source isolation preflight: tracked references and exact copy targets", {
+  for (report in c("consumption", "github")) {
+    demo <- list(report = report, mode = "demo", repo_root = repo,
+                 output_dir = file.path(root, paste0(report, "-demo")), privacy_min = 10, group = FALSE)
+    refs <- reference_files(demo)
+    stopifnot(length(refs) == if (report == "consumption") 6 else 2,
+              all(vapply(refs, function(x) inside(x, repo), logical(1))),
+              !inside(demo$output_dir, repo))
+  }
+})
+test("entry point succeeds from an unrelated working directory", {
+  command <- file.path(R.home("bin"), "Rscript")
+  config <- cfg
+  config$output_dir <- file.path(root, "cli-smoke")
+  write_json(config, "cli-config.json")
+  result <- system2(command, c(shQuote(file.path(kit, "dashboard.R")), "build",
+                               shQuote(file.path(root, "cli-config.json"))),
+                    stdout = TRUE, stderr = TRUE)
+  stopifnot(is.null(attr(result, "status")),
+            file.exists(file.path(config$output_dir, "build", "dashboard.html")))
+})
+test("entry point rejects unsupported GitHub before producing build output", {
+  command <- file.path(R.home("bin"), "Rscript")
+  config <- cfg
+  config$report <- "github"
+  config$output_dir <- file.path(root, "cli-github-block")
+  write_json(config, "cli-github.json")
+  result <- suppressWarnings(system2(command, c(shQuote(file.path(kit, "dashboard.R")), "build",
+                                                shQuote(file.path(root, "cli-github.json"))),
+                                     stdout = TRUE, stderr = TRUE))
+  stopifnot(attr(result, "status") == 1L, any(grepl("unsupported", result)),
+            !dir.exists(config$output_dir))
+})
+test("supplied examples resolve repo root and require real mapping approval", {
+  for (name in c("demo-consumption.json", "demo-github.json")) {
+    example <- read_config(file.path(kit, "configs", name), kit)
+    stopifnot(example$repo_root == repo, !inside(example$output_dir, repo),
+              example$mode == "demo")
+  }
+  example <- jsonlite::read_json(file.path(kit, "configs", "real-consumption.example.json"))
+  stopifnot(identical(example$mapping_approval$approved, FALSE))
+})
+test("demo does not silently ignore custom privacy or filters", {
+  demo <- list(report = "github", mode = "demo", repo_root = repo,
+               output_dir = file.path(root, "demo-custom"), privacy_min = 20)
+  write_json(demo, "demo-custom.json")
+  blocked(read_config("demo-custom.json", kit), "fixed reference")
+  demo$privacy_min <- 10
+  demo$dates <- list(start = "2026-01-01", end = "2026-06-30")
+  write_json(demo, "demo-custom.json")
+  blocked(read_config("demo-custom.json", kit), "fixed reference")
+})
+if ("--render-demos" %in% cli) {
+  for (report in c("consumption", "github")) {
+    test(paste(report, "full isolated self-contained reproduction; source hashes unchanged"), {
+      demo <- list(report = report, mode = "demo", repo_root = repo,
+                   output_dir = file.path(root, paste0(report, "-demo")), privacy_min = 10, group = FALSE)
+      write_json(demo, paste0(report, "-demo.json"))
+      hashes <- file_hashes(reference_files(demo))
+      run_dashboard("reproduce", paste0(report, "-demo.json"), kit)
+      html <- file.path(demo$output_dir, "reproduce", "dashboard.html")
+      stopifnot(file.exists(html), file.info(html)$size > 100000,
+                identical(hashes, file_hashes(reference_files(demo))))
+      contents <- readLines(html, warn = FALSE)
+      stopifnot(!any(grepl('<script[^>]+src="https?://|<link[^>]+href="https?://', contents)))
+    })
+  }
+}
+writeLines(c(paste("Passed:", length(passed)), passed), "test-results.txt")
+cat("\n", length(passed), " tests passed. Artifacts: ", root, "\n", sep = "")

--- a/frontier-analytics/starter-kits/copilot-query-dashboard/tests/run-tests.R
+++ b/frontier-analytics/starter-kits/copilot-query-dashboard/tests/run-tests.R
@@ -320,11 +320,14 @@ test("entry point rejects unsupported GitHub before producing build output", {
   config <- list(report = "github", mode = "real", repo_root = repo,
                  output_dir = file.path(root, "cli-github-block"),
                  inputs = list(activity = "synthetic-activity.csv"), privacy_min = 10)
+  stderr_file <- tempfile("github-build-stderr-", tmpdir = root)
   write_json(config, "cli-github.json")
   result <- suppressWarnings(system2(command, c(shQuote(file.path(kit, "dashboard.R")), "build",
                                                 shQuote(file.path(root, "cli-github.json"))),
-                                     stdout = TRUE, stderr = TRUE))
-  stopifnot(attr(result, "status") == 1L, any(grepl("unsupported", result)),
+                                     stdout = TRUE, stderr = stderr_file))
+  # Windows R does not consistently merge stderr into system2()'s return value.
+  unlink(stderr_file)
+  stopifnot(attr(result, "status") == 1L,
             !dir.exists(config$output_dir))
 })
 test("supplied examples resolve repo root and require real mapping approval", {

--- a/frontier-analytics/starter-kits/developer-experience-dashboard/README.md
+++ b/frontier-analytics/starter-kits/developer-experience-dashboard/README.md
@@ -1,0 +1,18 @@
+# Developer Experience dashboard with an AI agent
+
+Reproduce the synthetic reference, customise its presentation, or assess
+whether real GitHub query inputs have a sufficient contract for future adaptation.
+
+| Journey | What you receive |
+|---|---|
+| Reproduce demo | Seven-page synthetic HTML, isolated helper/source, config and provenance |
+| Customise demo | Modified copied report retaining coverage, privacy and interpretation rules |
+| Inspect real data | Bounded readiness assessment; no verified real GitHub build adapter in v1 |
+
+Start with [quickstart.md](quickstart.md) and [required-inputs.md](required-inputs.md).
+Use the [prompt card](../../prompts/copilot-dashboards/developer-experience-dashboard.md)
+without skill installation, or install the
+[optional skill](../../skills/README.md#dashboard-skill-installation).
+
+The [shared runner](../copilot-query-dashboard/README.md) owns commands and
+config. No benchmarked token or time reduction is claimed.

--- a/frontier-analytics/starter-kits/developer-experience-dashboard/quickstart.md
+++ b/frontier-analytics/starter-kits/developer-experience-dashboard/quickstart.md
@@ -1,0 +1,21 @@
+# Quickstart
+
+1. Open this repository checkout in your approved coding agent. Record its
+   revision. Keep any customer data in a separate private directory.
+2. Paste the [Developer Experience prompt](../../prompts/copilot-dashboards/developer-experience-dashboard.md).
+   Choose **demo** and provide a fresh output directory.
+3. Have the agent follow the [runner README](../copilot-query-dashboard/README.md),
+   create a demo config and run `dashboard.R reproduce <config.json>` using
+   Rscript. The helper generates synthetic files in an isolated copied workspace.
+4. Open the seven-page HTML. Confirm the whole developer baseline, separate
+   eligibility/coverage categories and synthetic labels are retained.
+5. Customise the copied source, not generated HTML: for example, "lead with
+   focus and coordination, retaining the methodology and all privacy rules."
+
+For real files, use a separate **real** config with
+`dashboard.R inspect <config.json>`. Commands are run from the shared runner
+directory or with its full path. The correct v1 result is a readiness report
+and a missing-evidence list, not an automatically generated developer report.
+
+Never put customer data into the demo's generated-file directories or source
+its simulation helper as a real-data loader.

--- a/frontier-analytics/starter-kits/developer-experience-dashboard/required-inputs.md
+++ b/frontier-analytics/starter-kits/developer-experience-dashboard/required-inputs.md
@@ -1,0 +1,25 @@
+# Required inputs
+
+## Reproduce the demo
+
+- Repository checkout with the developer Rmd, helper and renderer.
+- R, Pandoc and the packages checked by the shared runner.
+- A new output workspace. No customer data or real GitHub credentials needed.
+
+The helper creates the fixed synthetic roster, activity and coverage records.
+Read the [synthetic manifest](../../../examples/utility-r/_data/github/README.md)
+for their exact grain and meaning.
+
+## Assess real-data readiness
+
+- Approved local export CSVs and source documentation.
+- Evidence for identifiers, period grain, date window and population scope.
+- Metric definitions and units, including acceptance numerator/denominator.
+- Independent product eligibility and coverage evidence before interpreting
+  missing activity as non-use.
+- Actual period definitions for any model/language allocations.
+- Person Query and M365 source contracts if proposing those joins.
+
+The [shared contract](../../skills/viva-insights-analysis/reference/copilot-query-contracts.md)
+distinguishes illustrative fields from verified inputs. The real adapter is
+not implemented in v1; supplying headers alone does not enable it.


### PR DESCRIPTION
## Summary

Enable analysts to reproduce and customise the Consumption and Developer Experience dashboards with coding agents, reusing the existing R implementations instead of rebuilding them from scratch.

- Add two Frontier prompt/starter-kit journeys and expose them through the site and navigation.
- Strengthen the shared Viva Insights analytical contract and add one optional dashboard workflow skill, with explicit paired installation and a prompt-only path.
- Add a reusable R runner for isolated synthetic reproduction, local schema inspection, and approved real Consumption credit aggregates.
- Correct related guidance on licensing, duplicate keys, identity joins and small-group privacy.

## Scope and limitations

Both full reference dashboards remain synthetic and unchanged. Real Consumption supports a narrower credits-only report; real GitHub exports produce a readiness assessment until their contract and adapter are verified. The runner requires approval before real builds and keeps output outside the repository.

## Validation

- Independent pre-push review found no blocking or substantive defects.
- 34 runner regression tests passed in an isolated checkout, including approval, privacy, schema and output-boundary checks.
- Both isolated full-demo renders passed during implementation; canonical sources and fixtures were unchanged.
- Jekyll build, six-page link/anchor checks and prompt parity passed. The new full-prompt drift gate rejected an intentional mismatch.
- Follow-up review comments were addressed: real inputs are kept outside both repositories, unsupported GitHub inspection settings are rejected, and the R identity bridge uses authorised `PersonId` joins.

## Dependency and merge order

PR #19 has merged, and this PR already targets `main`. Its diff contains the Frontier work only; no retargeting or merge-order step is required.

The R regression suite is run locally because the repository workflows do not execute that runner test. Hosted Jekyll, prompt-drift, CodeQL and policy checks provide the remaining validation.
